### PR TITLE
Add workaround for Windows

### DIFF
--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -126,7 +126,10 @@ reprex_selection <- function(
                             show = getOption("reprex.show", TRUE)
 ) {
   context <- rstudioapi::getSourceEditorContext()
-  selection <- newlined(rstudioapi::primary_selection(context)[["text"]])
+  text <- rstudioapi::primary_selection(context)[["text"]]
+  # workaround for Windows (https://github.com/tidyverse/reprex/issues/82)
+  Encoding(text) <- "UTF-8"
+  selection <- newlined(text)
 
   reprex(
     input = selection,


### PR DESCRIPTION
This should fix #82.

To be fair, though this PR fixes the problem that occurs during getting the selection from RStudio, some people still suffers the one that involves knitting. More precisely, `sink()` might be a problem for some people (See https://github.com/hadley/evaluate/issues/59), including me. Yes, I still fails to produce a correct reprex of `"Brüssel"`...:

``` r
"Brussel"
#> [1] "Brussel"
```

Still, this PR fixes some part of the problem, which should be meaningful for many Windows guys :)