### PR TITLE
Add library() calls for currently loaded packages if non-empty

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -200,6 +200,8 @@ reprex <- function(
     the_source <- ingest_input(input)
   }
 
+  the_source <- c(get_library_calls(), the_source)
+
   outfile_given <- !is.null(outfile)
   if (outfile_given && is.na(outfile)) {
     if (length(input) == 1 && !grepl("\n$", input)) {

--- a/R/search.R
+++ b/R/search.R
@@ -1,0 +1,25 @@
+get_library_calls <- function() {
+  loaded_packages <- get_loaded_packages()
+  non_base_packages <- filter_base_packages(loaded_packages)
+  if (length(non_base_packages) == 0) return(character())
+  c(
+    "# Packages already on the search path:",
+    "suppressPackageStartupMessages({",
+    paste0("  library(", non_base_packages, ")"),
+    "})",
+    "",
+    "# User code:"
+  )
+}
+
+get_loaded_packages <- function() {
+  pkg_rx <- "^package:"
+  gsub(pkg_rx, "", grep(pkg_rx, search(), value = TRUE))
+}
+
+filter_base_packages <- function(packages) {
+  installed <- installed.packages()[packages, ]
+  priority <- installed[, "Priority"]
+  non_base <- is.na(priority) | priority != "base"
+  rownames(installed)[non_base]
+}

--- a/R/search.R
+++ b/R/search.R
@@ -14,7 +14,11 @@ get_library_calls <- function() {
 
 get_loaded_packages <- function() {
   pkg_rx <- "^package:"
-  gsub(pkg_rx, "", grep(pkg_rx, search(), value = TRUE))
+  search_entries <- grep(pkg_rx, search(), value = TRUE)
+  package_names <- gsub(pkg_rx, "", search_entries)
+
+  # Reverse the order to obtain the order of loading:
+  rev(package_names)
 }
 
 filter_base_packages <- function(packages) {


### PR DESCRIPTION
Related to #70.

I have magrittr in every session, and I constantly forget adding it to a reprex. This PR is my approach to this problem, happy to discuss/extend/adapt as appropriate. The idea is to look at the currently loaded packages and translate them to `library()` calls.

This is how `reprex::reprex(1 %>% identity)` looks on my machine:

``` r
suppressPackageStartupMessages({
  library(magrittr)
})

1 %>% identity
#> [1] 1
```

The same with tidyverse loaded:

``` r
# Packages already on the search path:
suppressPackageStartupMessages({
  library(magrittr)
  library(tidyverse)
  library(ggplot2)
  library(tibble)
  library(tidyr)
  library(readr)
  library(purrr)
  library(dplyr)
})

# User code:
1 %>% identity
#> [1] 1
```

Things to add:

- [ ] an `add_loaded = TRUE` argument to `reprex()`
- [ ] shorter code if just one package is loaded
- [ ] ...