### PR TITLE
Escape prompts when used in regexes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex 0.1.1.9000
 
+  * custom prompts are now escaped when used in regexes (#98 @jimhester).
+
   * New `reprex_selection()` add-in reprexes the current selection, with options
     controlled by options `reprex.venue`, `reprex.si`, and `reprex.show` 
     (#56, #71, #81)

--- a/R/ensure.R
+++ b/R/ensure.R
@@ -22,7 +22,7 @@ ensure_not_dogfood <- function(x) {
 }
 
 ensure_no_prompts <- function(x, prompt = getOption("prompt")) {
-  regex <- paste0("^", prompt)
+  regex <- paste0("^", escape_regex(prompt))
   prompts <- grepl(regex, x)
   if (any(prompts)) {
     message("Removing leading prompts from reprex source.")

--- a/R/reprex-undo.R
+++ b/R/reprex-undo.R
@@ -113,7 +113,7 @@ reprex_undo <- function(x = NULL, is_md = FALSE, venue,
   } else if (is.null(prompt)) {        ## reprex_clean
     x_out <- x[!grepl(comment, x)]
   } else {                             ## reprex_rescue
-    regex <- paste0("^\\s*", prompt)
+    regex <- paste0("^\\s*", escape_regex(prompt))
     x_out <- x[grepl(regex, x)]
     x_out <- sub(regex, "", x_out)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -121,3 +121,8 @@ yesno <- function(..., yes = "yes", no = "no") {
   }
   TRUE
 }
+
+escape_regex <- function(x) {
+  chars <- c("*", ".", "?", "^", "+", "$", "|", "(", ")", "[", "]", "{", "}", "\\")
+  gsub(paste0("([\\", paste0(collapse = "\\", chars), "])"), "\\\\\\1", x, perl = TRUE)
+}


### PR DESCRIPTION
Doing so ensures prompts which contain special characters in regular
expressions do not cause errors or unintended regular expressions.

Fixes #98