### PR TITLE
Take control of tidyverse startup message; special case of #70

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     tools,
     utils,
     whisker
-Suggests:
+Suggests: 
     covr,
     devtools,
     formatR,
@@ -36,6 +36,7 @@ Suggests:
     testthat (>= 1.0.2.9000)
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 RoxygenNote: 6.0.1
-Remotes: r-pkgs/callr
+Remotes: r-pkgs/callr,
+    hadley/testthat
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     miniUI,
     rstudioapi,
     shiny,
-    testthat
+    testthat (>= 1.0.2.9000)
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 RoxygenNote: 6.0.1
 Remotes: r-pkgs/callr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex 0.1.1.9000
 
+  * `reprex()` gains the argument `tidyverse_quiet`, defaulting to `TRUE`, which affords control of the startup message of the tidyverse meta-package (important special case of #70, #100).
+
   * custom prompts are now escaped when used in regexes (#98 @jimhester).
 
   * New `reprex_selection()` add-in reprexes the current selection, with options

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -60,6 +60,9 @@
 #' @param opts_chunk,opts_knit Named list. Optional
 #'   \href{http://yihui.name/knitr/options/}{knitr chunk and package options},
 #'   respectively, to supplement or override reprex defaults. See Details.
+#' @param tidyverse_quiet Logical. Sets the option \code{tidyverse.quiet}, which
+#'   suppresses (\code{TRUE}, the default) or includes (\code{FALSE}) the
+#'   startup message for the tidyverse package.
 #'
 #' @return Character vector of rendered reprex, invisibly.
 #' @examples
@@ -175,12 +178,14 @@
 reprex <- function(
   x = NULL, venue = c("gh", "so", "r", "R"), si = FALSE, show = TRUE,
   input = NULL, outfile = NULL,
-  comment = "#>", opts_chunk = NULL, opts_knit = NULL) {
+  comment = "#>", opts_chunk = NULL, opts_knit = NULL,
+  tidyverse_quiet = TRUE) {
 
   venue <- tolower(match.arg(venue))
   stopifnot(is.logical(si), is.logical(show), is.character(comment))
   if (!is.null(input)) stopifnot(is.character(input))
   if (!is.null(outfile)) stopifnot(is.character(outfile) || is.na(outfile))
+  if (!is.null(tidyverse_quiet)) stopifnot(is.logical(tidyverse_quiet))
 
   the_source <- NULL
   ## capture source in character vector
@@ -233,6 +238,7 @@ reprex <- function(
       comment = comment,
       user_opts_chunk = opts_chunk,
       user_opts_knit = opts_knit,
+      tidyverse_quiet = as.character(tidyverse_quiet),
       chunk_tidy = prep_tidy(expr_input),
       body = paste(the_source, collapse = "\n")
     ))

--- a/inst/templates/REPREX.R
+++ b/inst/templates/REPREX.R
@@ -14,6 +14,7 @@
 {{/so}}
 
 #+ reprex-setup, include = FALSE
+options(tidyverse.quiet = {{{tidyverse_quiet}}})
 knitr::opts_chunk$set(collapse = TRUE, comment = "{{{comment}}}", error = TRUE)
 knitr::opts_knit$set(upload.fun = knitr::imgur_upload)
 {{{user_opts_chunk}}}

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -6,7 +6,7 @@
 \usage{
 reprex(x = NULL, venue = c("gh", "so", "r", "R"), si = FALSE,
   show = TRUE, input = NULL, outfile = NULL, comment = "#>",
-  opts_chunk = NULL, opts_knit = NULL)
+  opts_chunk = NULL, opts_knit = NULL, tidyverse_quiet = TRUE)
 }
 \arguments{
 \item{x}{An expression. If not given, \code{reprex()} looks for code in
@@ -42,6 +42,10 @@ to \code{"#>"}.}
 \item{opts_chunk, opts_knit}{Named list. Optional
 \href{http://yihui.name/knitr/options/}{knitr chunk and package options},
 respectively, to supplement or override reprex defaults. See Details.}
+
+\item{tidyverse_quiet}{Logical. Sets the option \code{tidyverse.quiet}, which
+suppresses (\code{TRUE}, the default) or includes (\code{FALSE}) the
+startup message for the tidyverse package.}
 }
 \value{
 Character vector of rendered reprex, invisibly.

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -1,0 +1,25 @@
+context("tidyverse")
+
+test_that("reprex() suppresses tidyverse startup message by default", {
+  skip_if_not_installed("tidyverse", minimum_version = "1.1.1.9000")
+  ret <- reprex(input = "library(tidyverse)\n", show = FALSE)
+  expect_false(any(grepl("#>", ret)))
+})
+
+test_that("reprex() has control over tidyverse startup message", {
+  skip_if_not_installed("tidyverse", minimum_version = "1.1.1.9000")
+
+  ret <- reprex(
+    input = "library(tidyverse)\n",
+    tidyverse_quiet = TRUE,
+    show = FALSE
+  )
+  expect_false(any(grepl("#>", ret)))
+
+  ret <- reprex(
+    input = "library(tidyverse)\n",
+    tidyverse_quiet = FALSE,
+    show = FALSE
+  )
+  expect_true(any(grepl("#>", ret)))
+})


### PR DESCRIPTION
What do you think @hadley? Conceptually and of the choice to default to `TRUE` instead of, say, consulting an option.

This solves a very special case of #70 Suppress package message argument, but it's also the only case that actively annoys me. The `tidyverse.quiet` (the official option) vs `tidyverse_quiet` (argname for `reprex()`) is a bit sad, but not sure what's better.