### PR TITLE
Do not show spinner when running tests interactively

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -323,6 +323,6 @@ reprex_ <- function(input) {
       rmarkdown::render(input, quiet = TRUE)
     },
     args = list(input = input),
-    spinner = interactive()
+    spinner = interactive() && !in_tests()
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,3 +126,7 @@ escape_regex <- function(x) {
   chars <- c("*", ".", "?", "^", "+", "$", "|", "(", ")", "[", "]", "{", "}", "\\")
   gsub(paste0("([\\", paste0(collapse = "\\", chars), "])"), "\\\\\\1", x, perl = TRUE)
 }
+
+in_tests <- function() {
+  nzchar(Sys.getenv("R_TESTS", "")) || as.logical(Sys.getenv("NOT_CRAN", "FALSE"))
+}


### PR DESCRIPTION
This turns off the callr spinner when running tests interactively. I don't think there is a function in testthat to tell when tests are being run. The `in_tests()` function should return true when tests are run with devtools and from `R CMD check`.