### PR TITLE
Add advertisement as prose plus a link rather than code.

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -245,9 +245,6 @@ reprex <- function(x = NULL,
       message("Install the styler package in order to use `styler = TRUE`.")
     }
   }
-  if (advertise) {
-    the_source <- c("reprex::reprex_info()", "", the_source)
-  }
 
   outfile_given <- !is.null(outfile)
   files <- make_filenames(make_filebase(outfile, infile))
@@ -270,6 +267,7 @@ reprex <- function(x = NULL,
     user_opts_knit = prep_opts(opts_knit, which = "knit"),
     tidyverse_quiet = as.character(tidyverse_quiet),
     std_file = std_file,
+    advertisement = advertise,
     body = paste(the_source, collapse = "\n")
   ))
   writeLines(the_source, r_file)

--- a/inst/templates/REPREX.R
+++ b/inst/templates/REPREX.R
@@ -22,6 +22,10 @@ lines <- if (length(lines) > 0) lines else "nothing written to stdout or stderr"
 cat(lines, sep = "\n")
 {{/std_file}}
 
+{{#advertisement}}
+#' Created on `r Sys.Date()` by the [reprex package (`r utils::packageVersion("reprex")`)](https://cran.r-project.org/package=reprex).
+{{/advertisement}}
+
 {{#si}}
 {{{si_start}}}
 {{#devtools}}


### PR DESCRIPTION
```r
reprex::reprex(1 + 1)
```

![screenshot 2017-11-07 13 30 41](https://user-images.githubusercontent.com/205275/32510837-e1bcf234-c3bf-11e7-8eca-2e4dc6df7ba7.png)

Fixes https://github.com/tidyverse/reprex/issues/69