### PR TITLE
Fix reprex via "Rstudio selection" addin

### DIFF
--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -142,7 +142,7 @@ rstudio_context <- function() {
 
 rstudio_text_tidy <- function(x) {
   Encoding(x) <- "UTF-8"
-  x <- scan(text = x, what = "", sep = "\n", quiet = TRUE)
+  x <- strsplit(x, "\n")[[1]]
 
   n <- length(x)
   if (!grepl("\n$", x[[n]])) {

--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -142,7 +142,7 @@ rstudio_context <- function() {
 
 rstudio_text_tidy <- function(x) {
   Encoding(x) <- "UTF-8"
-  x <- vapply(rlang::parse_exprs(x), rlang::expr_text, character(1))
+  x <- scan(text = x, what = "", sep = "\n")
 
   n <- length(x)
   if (!grepl("\n$", x[[n]])) {

--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -142,6 +142,7 @@ rstudio_context <- function() {
 
 rstudio_text_tidy <- function(x) {
   Encoding(x) <- "UTF-8"
+  x <- vapply(rlang::parse_exprs(x), rlang::expr_text, character(1))
 
   n <- length(x)
   if (!grepl("\n$", x[[n]])) {

--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -142,7 +142,7 @@ rstudio_context <- function() {
 
 rstudio_text_tidy <- function(x) {
   Encoding(x) <- "UTF-8"
-  x <- scan(text = x, what = "", sep = "\n")
+  x <- scan(text = x, what = "", sep = "\n", quiet = TRUE)
 
   n <- length(x)
   if (!grepl("\n$", x[[n]])) {


### PR DESCRIPTION
When I stopped accepting multiple lines of code catenated into a single string (https://github.com/tidyverse/reprex/commit/61b6048cde532a19776df55d4171da3792609e83), I forgot that this is how source comes when using `reprex_selection()`. This puts into same format as usual `input`, i.e. returns a character vector.