### PR TITLE
Don't add <br/> when venue = "so"; closes #133

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,9 @@ These look like `reprex(..., arg = opt(DEFAULT), ...)` in the help file. This is
     (#56, #71, #81)
 
   * `reprex_addin()` displays notificaton as inline dialog.
+  
+  * When `venue = "so"`, `reprex()` no longer inserts `<br/>` at the beginning 
+    of the results (#133)
 
 # reprex 0.1.1
 

--- a/R/reprex-undo.R
+++ b/R/reprex-undo.R
@@ -198,9 +198,9 @@ classify_lines <- function(x, comment = "^#>") {
   wut <- ifelse(grepl("^    ", x), "code", "prose")
   wut <- ifelse(wut == "code" & grepl(comment, x), "output", wut)
 
-  so_special <- c("<!-- language-all: lang-r -->", "<br/>")
-  if (identical(x[1:2], so_special)) {
-    wut[1:2] <- "so_header"
+  so_special <- "<!-- language-all: lang-r -->"
+  if (identical(x[1], so_special)) {
+    wut[1] <- "so_header"
   }
 
   wut

--- a/R/whisker.R
+++ b/R/whisker.R
@@ -44,7 +44,7 @@ fodder <- list(
   ),
   so = list(
     yaml = yaml_md,
-    so_syntax_highlighting = "#'<!-- language-all: lang-r -->"
+    so_syntax_highlighting = "#'<!-- language-all: lang-r -->\\n"
   ),
   r = list(
     yaml = yaml_gfm

--- a/R/whisker.R
+++ b/R/whisker.R
@@ -44,7 +44,7 @@ fodder <- list(
   ),
   so = list(
     yaml = yaml_md,
-    so_syntax_highlighting = "#'<!-- language-all: lang-r --><br/>"
+    so_syntax_highlighting = "#'<!-- language-all: lang-r -->"
   ),
   r = list(
     yaml = yaml_gfm

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -8,7 +8,6 @@ test_that("venue = 'so' works", {
   )
   output <- c(
     "<!-- language-all: lang-r -->",
-    "<br/>",
     "",
     "Hello world",
     "",


### PR DESCRIPTION
Drops excess `<br/>` tag when `venue = "so"` in `reprex()`. Updates `reprex_undo()` and tests so all tests pass.

Because dropping the `<br/>` stopped an important newline after `<!-- language-all: lang-r -->` from getting inserted, I added `\\n` to the end of that `lang` comment, but it could probably be inserted with a second empty string instead where `<br/>` was, if you prefer. I'm not sure which makes more sense/is more consistent/if anyone cares.