### PR TITLE
Fix "Render reprex ..."  gadget for reading from file

### DIFF
--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -75,7 +75,7 @@ reprex_addin <- function() { # nocov start
 
   server <- function(input, output, session) {
     shiny::observeEvent(input$done, {
-      shiny::stopApp(list(
+      shiny::stopApp(reprex_guess(
         input$source,
         input$venue,
         input$source_file,
@@ -86,9 +86,8 @@ reprex_addin <- function() { # nocov start
   }
 
   app <- shiny::shinyApp(ui, server, options = list(quiet = TRUE))
-  result <- shiny::runGadget(app, viewer = shiny::dialogViewer("Render reprex"))
+  shiny::runGadget(app, viewer = shiny::dialogViewer("Render reprex"))
 
-  do.call(reprex_guess, result)
 }
 
 reprex_guess <- function(source, venue = "gh", source_file = NULL,


### PR DESCRIPTION
Necessary to restore functioning of the "Render reprex ..." gadget/addin if user wants to read from file.

In the previous version, the app is stopped *before* `reprex()` gets called, which meant the temp file obtained via `shiny::fileInput()` was deleted too soon.

cc @hadley I think this was an unintended consequence of some cleanup you did. I've been able to retain almost all of it. Speak up if you object to this. It leads to a slight lag between `reprex()` finishing and the disappearance of the gadget, which is probably what you were getting rid of. I could also just drop "arbitrary file" as a method of input here.