### PR TITLE
Don't wrap GitHub reprexes

### DIFF
--- a/R/whisker.R
+++ b/R/whisker.R
@@ -31,7 +31,8 @@ output:
   md_document:
     pandoc_args: [
       '-f', 'markdown-implicit_figures',
-      '-t', 'commonmark'
+      '-t', 'commonmark',
+      '--wrap', 'none'
     ]
 ---"
 yaml_gfm <- trim_ws(gsub("\\n", "\n#' ", yaml_gfm))


### PR DESCRIPTION
This is escpecially visible when the credits are wrapped. Closes #140.

Example:

``` r
TRUE
```

Created on 2017-12-22 by the [reprex package](http://reprex.tidyverse.org) (v0.1.1.9000).