### PR TITLE
Add credits as quote

### DIFF
--- a/inst/templates/REPREX.R
+++ b/inst/templates/REPREX.R
@@ -15,7 +15,7 @@ knitr::opts_knit$set(upload.fun = {{{upload_fun}}})
 {{{std_file_stub}}}
 
 {{#advertisement}}
-#' Created on `r Sys.Date()` by the [reprex package](http://reprex.tidyverse.org) (v`r utils::packageVersion("reprex")`).
+#' > Created on `r Sys.Date()` by the [reprex package](http://reprex.tidyverse.org) (v`r utils::packageVersion("reprex")`).
 {{/advertisement}}
 
 {{#si}}


### PR DESCRIPTION
so that further text can be added below the reprex. Example:

``` r
TRUE
```

> Created on 2017-12-22 by the [reprex
> package](http://reprex.tidyverse.org) (v0.1.1.9000).

This is some dummy text below the example.