### PR TITLE
Adapt reprex_addin to be more useful when the clipboard isn't available

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -82,7 +82,10 @@
 #'   process, nor is there any guarantee that the lines from standard output and
 #'   standard error are in correct chronological order. See [callr::r_safe()]
 #'   for more. Read more about [opt()].
-#'
+#' @param ask_file_edit Logical. When clipboard is not available and the
+#'   user is, ask the user whether to open the reprex in a file editor pane
+#'   (defaults to TRUE).
+#' 
 #' @return Character vector of rendered reprex, invisibly.
 #' @examples
 #' \dontrun{
@@ -206,7 +209,8 @@ reprex <- function(x = NULL,
                    opts_knit = NULL,
                    tidyverse_quiet = opt(TRUE),
                    std_out_err = opt(FALSE),
-                   render = TRUE) {
+                   render = TRUE,
+                   ask_file_edit = TRUE) {
   venue <- tolower(venue)
   venue <- match.arg(venue)
   venue <- ds_is_gh(venue)
@@ -316,7 +320,7 @@ reprex <- function(x = NULL,
   if (clipboard_available()) {
     clipr::write_clip(out_lines)
     message("Rendered reprex is on the clipboard.")
-  } else if (user_available()) {
+  } else if (user_available() & ask_file_edit) {
     clipr::dr_clipr()
     message(
       "Unable to put result on the clipboard. How to get it:\n",

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -8,7 +8,7 @@ reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh", "so",
   "ds", "r"), advertise = opt(TRUE), si = opt(FALSE), style = opt(FALSE),
   show = opt(TRUE), comment = opt("#>"), opts_chunk = NULL,
   opts_knit = NULL, tidyverse_quiet = opt(TRUE), std_out_err = opt(FALSE),
-  render = TRUE)
+  render = TRUE, ask_file_edit = TRUE)
 }
 \arguments{
 \item{x}{An expression. If not given, \code{reprex()} looks for code in
@@ -74,6 +74,10 @@ for more. Read more about \code{\link[=opt]{opt()}}.}
 \item{render}{Logical. Whether to render the reprex or just create the
 templated \code{.R} file. Defaults to \code{TRUE}. Mostly for internal testing
 purposes.}
+
+\item{ask_file_edit}{Logical. When clipboard is not available and the
+user is, ask the user whether to open the reprex in a file editor pane
+(defaults to TRUE).}
 }
 \value{
 Character vector of rendered reprex, invisibly.


### PR DESCRIPTION
For your consideration, adaptions to the reprex_gadget so that if the clipboard is unavailable, shiny textArea inputs are available so you can paste the data in and copy it out. This is similar to #151, but I think I like the modal box of the gadget better than opening a new source file.
 
![image](https://user-images.githubusercontent.com/2104579/34798760-ec5926aa-f622-11e7-8e14-aa03ff9fce8b.png)

I also added an option to reprex that turns off the behavior from #151 because it got in the way here.

Thank you (I absolutely love this package)!