### PR TITLE
Fix reprex preview on windows

### DIFF
--- a/R/filepaths.R
+++ b/R/filepaths.R
@@ -75,7 +75,7 @@ make_filenames <- function(filebase = "foo", suffix = "reprex") {
 }
 
 force_tempdir <- function(x) {
-  if (identical(normalizePath(tempdir()), dirname(normalizePath(x)))) {
+  if (identical(normalizePath(tempdir()), normalizePath(dirname(x)))) {
     return(x)
   }
   tmp_file <- file.path(tempdir(), basename(x))


### PR DESCRIPTION
closes #162 

There is a forced copy of the built html in `tempdir()` that is wrongly done because of incorrectly formated file paths.

This PR ensures that the `identical` test succeed and forced copy is skipped when html file is already in `tempdir()` 