### PR TITLE
Inject standard output and error *after* render

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -270,7 +270,7 @@ reprex <- function(x = NULL,
     user_opts_chunk = prep_opts(opts_chunk, which = "chunk"),
     user_opts_knit = prep_opts(opts_knit, which = "knit"),
     tidyverse_quiet = as.character(tidyverse_quiet),
-    std_file = std_file,
+    std_file_stub = if (std_out_err) paste0("#' `", std_file, "`\n#'"),
     advertisement = advertise,
     body = paste(the_source, collapse = "\n")
   ))
@@ -286,6 +286,14 @@ reprex <- function(x = NULL,
   message("Rendering reprex...")
   ## when venue = "r", the reprex_file != md_file, so we need both
   reprex_file <- md_file <- reprex_(r_file, std_file)
+
+  if (std_out_err) {
+    ## prepare standard output and error to inject into .md
+    enfence(std_file, tag = "standard output and standard error")
+    ## replace backtick'ed std_file with the contents of std_file
+    inject_file(reprex_file, std_file)
+  }
+
   if (outfile_given) {
     ## pathstem = the common part of the two paths
     pathstem <- path_stem(r_file, md_file)

--- a/R/utils.R
+++ b/R/utils.R
@@ -81,3 +81,27 @@ ds_is_gh <- function(venue) {
 }
 
 pandoc2.0 <- function() rmarkdown::pandoc_available("2.0")
+
+enfence <- function(path,
+                    tag = NULL,
+                    fallback = "-- nothing to show --") {
+  lines <- readLines(path, encoding = "UTF-8")
+  if (length(lines) == 0) {
+    lines <- fallback
+  }
+  lines <- paste0(c(tag, "``` sh", lines, "```"), collapse = "\n")
+  writeLines(lines, path)
+  path
+}
+
+inject_file <- function(path, inject_path) {
+  lines <- readLines(path, encoding = "UTF-8")
+  lines <- sub(paste0("`", inject_path, "`"), "{{{inject_lines}}}", lines)
+  inject_lines <- readLines(inject_path, encoding = "UTF-8")
+  lines <- whisker::whisker.render(
+    lines,
+    data = list(inject_lines = paste0(inject_lines, collapse = "\n"))
+  )
+  writeLines(lines, path)
+  path
+}

--- a/inst/templates/REPREX.R
+++ b/inst/templates/REPREX.R
@@ -12,15 +12,7 @@ knitr::opts_knit$set(upload.fun = {{{upload_fun}}})
 #+ reprex-body
 {{{body}}}
 
-{{#std_file}}
-#+ include = FALSE
-lines <- readLines("{{{std_file}}}")
-lines <- if (length(lines) > 0) lines else "nothing written to stdout or stderr"
-
-#' standard output and standard error
-#+ std-out-err, echo = FALSE
-cat(lines, sep = "\n")
-{{/std_file}}
+{{{std_file_stub}}}
 
 {{#advertisement}}
 #' Created on `r Sys.Date()` by the [reprex package](http://reprex.tidyverse.org) (v`r utils::packageVersion("reprex")`).

--- a/tests/testthat/test-optionally.R
+++ b/tests/testthat/test-optionally.R
@@ -37,5 +37,5 @@ test_that("`std_out_err` can be set via option", {
     list(reprex.std_out_err = TRUE),
     out <- reprex(1, render = FALSE)
   )
-  expect_match(out, "standard output and standard error", all = FALSE)
+  expect_match(out, "std_out_err", all = FALSE)
 })

--- a/tests/testthat/test-stdout-stderr.R
+++ b/tests/testthat/test-stdout-stderr.R
@@ -3,11 +3,16 @@ context("stdout-stderr")
 test_that("stdout is captured", {
   out <- reprex(system2("echo", args = "blah"), std_out_err = TRUE, show = FALSE)
   expect_match(out, "standard output and standard error", all = FALSE)
-  expect_match(out, "#> blah", all = FALSE)
+  expect_match(out, "blah", all = FALSE)
 })
 
 test_that("stdout placeholder appears if nothing is captured", {
   out <- reprex(1:4, std_out_err = TRUE, show = FALSE)
   expect_match(out, "standard output and standard error", all = FALSE)
-  expect_match(out, "#> nothing written to stdout or stderr", all = FALSE)
+  expect_match(out, "nothing to show", all = FALSE)
+})
+
+test_that("stdout placeholder is absent if explicitly excluded", {
+  out <- reprex(1:4, std_out_err = FALSE, show = FALSE)
+  expect_false(any(grepl("standard output and standard error", out)))
 })


### PR DESCRIPTION
Reading the file during render potentially creates a race condition