### PR TITLE
HTTPS on Stack Overflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
 Description: Convenience wrapper that uses the 'rmarkdown' package to render
   small snippets of code to target formats that include both code and output.
   The goal is to encourage the sharing of small, reproducible, and runnable
-  examples on code-oriented websites, such as <http://stackoverflow.com> and
+  examples on code-oriented websites, such as <https://stackoverflow.com> and
   <https://github.com>, or in email. 'reprex' also extracts clean, runnable R
   code from various common formats, such as copy/paste from an R session.
 License: MIT + file LICENSE

--- a/R/reprex-undo.R
+++ b/R/reprex-undo.R
@@ -191,7 +191,7 @@ classify_lines_bt <- function(x, comment = "^#>") {
 ## classify_lines()
 ## x = presumably output of reprex(..., venue = "so"), i.e. NOT Github-flavored
 ## markdown in a character vector, with code blocks indented with 4 spaces
-## http://stackoverflow.com/editing-help
+## https://stackoverflow.com/editing-help
 ## returns character vector
 ## calls each line of x like so:
 ##   * code = inside a code block indented by 4 spaces

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -165,7 +165,7 @@
 #' unlink(list.files(pattern = "blarg"), recursive = TRUE)
 #'
 #' ## target venue = Stack Overflow
-#' ## http://stackoverflow.com/editing-help
+#' ## https://stackoverflow.com/editing-help
 #' ret <- reprex({
 #'   x <- 1:4
 #'   y <- 2:5

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ oo <- options(reprex.advertise = FALSE)
 [![Coverage status](https://codecov.io/gh/tidyverse/reprex/branch/master/graph/badge.svg)](https://codecov.io/github/tidyverse/reprex?branch=master)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
 
-Prepare reprexes for posting to [GitHub issues](https://guides.github.com/features/issues/), [StackOverflow](http://stackoverflow.com/questions/tagged/r), or [Slack snippets](https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet). What is a `reprex`? It's a **repr**oducible **ex**ample, as coined by [Romain Francois](https://twitter.com/romain_francois/status/530011023743655936).
+Prepare reprexes for posting to [GitHub issues](https://guides.github.com/features/issues/), [StackOverflow](https://stackoverflow.com/questions/tagged/r), or [Slack snippets](https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet). What is a `reprex`? It's a **repr**oducible **ex**ample, as coined by [Romain Francois](https://twitter.com/romain_francois/status/530011023743655936).
 
 <a href="https://nypdecider.files.wordpress.com/2014/08/help-me-help-you.gif"><img src="man/figures/help-me-help-you.png" align="right" /></a>
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ status](https://codecov.io/gh/tidyverse/reprex/branch/master/graph/badge.svg)](h
 
 Prepare reprexes for posting to [GitHub
 issues](https://guides.github.com/features/issues/),
-[StackOverflow](http://stackoverflow.com/questions/tagged/r), or [Slack
+[StackOverflow](https://stackoverflow.com/questions/tagged/r), or [Slack
 snippets](https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet).
 What is a `reprex`? It’s a **repr**oducible **ex**ample, as coined by
 [Romain

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -195,7 +195,7 @@ list.files(pattern = "blarg")
 unlink(list.files(pattern = "blarg"), recursive = TRUE)
 
 ## target venue = Stack Overflow
-## http://stackoverflow.com/editing-help
+## https://stackoverflow.com/editing-help
 ret <- reprex({
   x <- 1:4
   y <- 2:5

--- a/vignettes/reprex-dos-and-donts.Rmd
+++ b/vignettes/reprex-dos-and-donts.Rmd
@@ -68,7 +68,7 @@ The remaining 20% of the time, you will create a reprex that is more likely to e
 
 ## Further reading:
 
-[How to make a great R reproducible example?](http://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example/16532098) thread on StackOverflow
+[How to make a great R reproducible example?](https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example/16532098) thread on StackOverflow
 
 [How to write a reproducible example](http://adv-r.had.co.nz/Reproducibility.html) from Hadley Wickham's [Advanced R book](http://adv-r.had.co.nz)
 


### PR DESCRIPTION
Stack Overflow now support HTTPS since [May 22, 2017](https://stackoverflow.blog/2017/05/22/stack-overflow-flipped-switch-https/) 🎉 . Tweak replaced `http://stackoverflow.com` to `https://stackoverflow.com` exclude `docs/` and `internal/` files.

This PR not user-facing changes.