### PR TITLE
Safeguard against missing pandoc

### DIFF
--- a/R/whisker.R
+++ b/R/whisker.R
@@ -28,10 +28,12 @@ yaml_md <- function(flavor = c("gfm", "md"),
   c("      '-f', 'markdown-implicit_figures',",
     "      '-t', 'commonmark',")
     },
-    if (pandoc_version < "1.16") {
+    if (!is.null(pandoc_version)) {
+      if (pandoc_version < "1.16") {
     "      --no-wrap"
-    } else {
+      } else {
     "      --wrap=preserve"
+      }
     },
     "    ]",
     "---"


### PR DESCRIPTION
It is mentioned in `SystemRequirements`, but even trying to install *reprex* currently fails if pandoc is not installed. Maybe we could try resubmitting to CRAN with this patch?