### PR TITLE
Adding minimal version dependency on styler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rprojroot,
     rstudioapi,
     shiny,
-    styler,
+    styler (>= 1.0.2),
     testthat (>= 2.0.0)
 VignetteBuilder: knitr
 Encoding: UTF-8


### PR DESCRIPTION
styler `v1.0.2` is now available on CRAN and I suggest to add a minimal version dependency to reprex to import this version. Most notable fixes (including critical fixes like implicit dependency removal) were already present in a prior release `v1.0.1`, but currently, reprex does not specify a minimal version for styler. You can find the changelog [here](http://styler.r-lib.org/news/index.html).