### PR TITLE
rework file opening behavior

### DIFF
--- a/R/filepaths.R
+++ b/R/filepaths.R
@@ -2,7 +2,7 @@
 make_filebase <- function(outfile = NULL, infile = NULL) {
   if (is.null(outfile)) {
     ## work inside a new directory, within session temp directory
-    target_dir <- path_real(dir_create(file_temp("reprex")))
+    target_dir <- fs::path_real(fs::dir_create(fs::file_temp("reprex")))
     ## example: /private/var/.../.../.../reprex97d77de2835c/reprex
     return(path(target_dir, "reprex"))
   }
@@ -14,7 +14,7 @@ make_filebase <- function(outfile = NULL, infile = NULL) {
   if (is.null(infile)) {
     ## outfile = NA, infile = NULL --> reprex in working directory
     ## example: reprexbfa165580676
-    path_file(file_temp("reprex"))
+    fs::path_file(fs::file_temp("reprex"))
   } else {
     ## outfile = NA, infile = "sthg" --> follow infile's lead
     ## example: basename_of_infile
@@ -44,14 +44,14 @@ force_tempdir <- function(path) {
   if (is_in_tempdir(path)) {
     path
   } else {
-    file_copy(path, path_temp(path_file(path)), overwrite = TRUE)
+    fs::file_copy(path, fs::path_temp(fs::path_file(path)), overwrite = TRUE)
   }
 }
 
 is_in_tempdir <- function(path) {
   identical(
-    path_real(path_temp()),
-    path_common(path_real(c(path, path_temp())))
+    fs::path_real(fs::path_temp()),
+    fs::path_common(fs::path_real(c(path, fs::path_temp())))
   )
 }
 

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -374,7 +374,7 @@ reprex <- function(x = NULL,
       "  * ", reprex_file
     )
     if (yep("Open the output file for manual copy?")) {
-      withr::defer(utils::file.edit(reprex_file))
+      withr::defer(file_edit(reprex_file))
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,3 +97,11 @@ collapse <- function(x, sep = "\n") {
 backtick <- function(x) encodeString(x, quote = "`")
 
 newline <- function(x) paste0(x, "\n")
+
+file_edit <- function(...) {
+  if (exists("file.edit", envir = globalenv())) {
+    get("file.edit", envir = globalenv())(...)
+  } else {
+    utils::file.edit(...)
+  }
+}

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -4,11 +4,10 @@
 \alias{reprex}
 \title{Render a reprex}
 \usage{
-reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh",
-  "so", "ds", "r", "rtf"), render = TRUE, advertise = NULL,
-  si = opt(FALSE), style = opt(FALSE), show = opt(TRUE),
-  comment = opt("#>"), tidyverse_quiet = opt(TRUE),
-  std_out_err = opt(FALSE))
+reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh", "so",
+  "ds", "r", "rtf"), render = TRUE, advertise = NULL, si = opt(FALSE),
+  style = opt(FALSE), show = opt(TRUE), comment = opt("#>"),
+  tidyverse_quiet = opt(TRUE), std_out_err = opt(FALSE))
 }
 \arguments{
 \item{x}{An expression. If not given, \code{reprex()} looks for code in

--- a/man/un-reprex.Rd
+++ b/man/un-reprex.Rd
@@ -7,13 +7,13 @@
 \alias{reprex_rescue}
 \title{Un-render a reprex}
 \usage{
-reprex_invert(input = NULL, outfile = NULL, venue = c("gh", "so",
-  "ds", "r"), comment = opt("#>"))
+reprex_invert(input = NULL, outfile = NULL, venue = c("gh", "so", "ds",
+  "r"), comment = opt("#>"))
 
 reprex_clean(input = NULL, outfile = NULL, comment = opt("#>"))
 
-reprex_rescue(input = NULL, outfile = NULL,
-  prompt = getOption("prompt"), continue = getOption("continue"))
+reprex_rescue(input = NULL, outfile = NULL, prompt = getOption("prompt"),
+  continue = getOption("continue"))
 }
 \arguments{
 \item{input}{Character. If has length one and lacks a terminating newline,
@@ -21,8 +21,9 @@ interpreted as the path to a file containing reprex code. Otherwise,
 assumed to hold reprex code as character vector. If not provided, the
 clipboard is consulted for input.}
 
-\item{outfile}{Optional basename for output file. When \code{NULL}, no file is
-left behind. If \code{outfile = "foo"}, expect an output file in current working
+\item{outfile}{Optional basename for output file. When \code{NULL}
+(default), reprex writes to temp files below the session temp directory.
+If \code{outfile = "foo"}, expect an output file in current working
 directory named \code{foo_clean.R}. If \code{outfile = NA}, expect on output file in
 a location and with basename derived from \code{input}, if a path, or in
 current working directory with basename derived from \code{\link[=tempfile]{tempfile()}}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -21,7 +21,7 @@ expect_error_free <- function(...) {
 
 ## set wd to session temp dir, execute testing code, restore previous wd
 temporarily <- function(env = parent.frame()) {
-  withr::local_dir(path_temp(), .local_envir = env)
+  withr::local_dir(fs::path_temp(), .local_envir = env)
 }
 
 ## call during interactive test development to fake being "in tests" and thereby


### PR DESCRIPTION
This PR addresses the file.edit problem discussed in #204 and also changes the undo functions so that they always open up a file containing the clean r code (see https://github.com/tidyverse/reprex/issues/67#issuecomment-420456137 for discussion)
