### PR TITLE
Trim rendering context from rlang backtraces

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -384,7 +384,10 @@ reprex <- function(x = NULL,
 reprex_render <- function(input, std_out_err = NULL) {
   callr::r_safe(
     function(input) {
-      options(keep.source = TRUE)
+      options(
+        keep.source = TRUE,
+        rlang_trace_top_env = globalenv()
+      )
       rmarkdown::render(input, quiet = TRUE, envir = globalenv())
     },
     args = list(input = input),

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -26,3 +26,11 @@ test_that("reprex() doesn't leak files by default", {
   ret <- reprex(readLines("test.txt"), show = FALSE, advertise = FALSE)
   expect_match(ret, "cannot open file 'test.txt'", all = FALSE)
 })
+
+test_that("markdown::render() context is trimmed from rlang backtrace", {
+  skip_on_cran()
+  input <- "f <- function() g(); g <- function() h(); h <- function() rlang::abort('foo'); f()\n"
+  ret <- reprex(input = input, show = FALSE, advertise = FALSE)
+  expect_false(any(grepl("tryCatch", ret)))
+  expect_false(any(grepl("markdown::render", ret)))
+})


### PR DESCRIPTION
With dev rlang, `abort()` errors always prints the full backtrace in non-interactive contexts such as reprex, instead of the reminder to call `last_error()`. This doesn't work well with reprex because the backtrace includes the rendering context. This patch fixes this by setting the top environment for rlang backtraces.

After this patch:

```r
f <- function() g()
g <- function() h()
h <- function() rlang::abort("foo")
f()
#> Error: foo
#> Backtrace:
#>     █
#>  1. └─global::f()
#>  2.   └─global::g()
#>  3.     └─global::h()

Created on 2019-01-03 by the reprex package (v0.2.0)
```

Before this patch:

```r
f <- function() g()
g <- function() h()
h <- function() rlang::abort("foo")
f()
#> Error: foo
#> Backtrace:
#>      █
#>   1. ├─base::tryCatch(...)
#>   2. │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>   3. │   ├─base:::tryCatchOne(...)
#>   4. │   │ └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   5. │   └─base:::tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
#>   6. │     └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>   7. │       └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   8. ├─base::withCallingHandlers(...)
#>   9. ├─base::saveRDS(...)
#>  10. ├─base::do.call(...)
#>  11. ├─(function (what, args, quote = FALSE, envir = parent.frame()) ...
#>  12. ├─(function (input) ...
#>  13. │ └─rmarkdown::render(input, quiet = TRUE, envir = globalenv())
#>  14. │   └─knitr::knit(...)
#>  15. │     └─knitr:::process_file(text, output)
#>  16. │       ├─base::withCallingHandlers(...)
#>  17. │       ├─knitr:::process_group(group)
#>  18. │       └─knitr:::process_group.block(group)
#>  19. │         └─knitr:::call_block(x)
#>  20. │           └─knitr:::block_exec(params)
#>  21. │             ├─knitr:::in_dir(...)
#>  22. │             └─knitr:::evaluate(...)
#>  23. │               └─evaluate::evaluate(...)
#>  24. │                 └─evaluate:::evaluate_call(...)
#>  25. │                   ├─evaluate:::timing_fn(...)
#>  26. │                   ├─evaluate:::handle(...)
#>  27. │                   │ └─base::try(f, silent = TRUE)
#>  28. │                   │   └─base::tryCatch(...)
#>  29. │                   │     └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>  30. │                   │       └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  31. │                   │         └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>  32. │                   ├─base::withCallingHandlers(...)
#>  33. │                   ├─base::withVisible(eval(expr, envir, enclos))
#>  34. │                   └─base::eval(expr, envir, enclos)
#>  35. │                     └─base::eval(expr, envir, enclos)
#>  36. └─global::f()
#>  37.   └─global::g()
#>  38.     └─global::h()

Created on 2019-01-03 by the reprex package (v0.2.0).
```