### PR TITLE
Use read_utf8() and write_utf8()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     rmarkdown,
     utils,
     whisker,
-    withr
+    withr,
+    xfun
 Suggests: 
     covr,
     devtools,

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -301,13 +301,13 @@ reprex <- function(x = NULL,
     comment = comment, tidyverse_quiet = tidyverse_quiet, std_file = std_file
   )
   src <- apply_template(src, data)
-  xfun::write_utf8(src, r_file)
+  write_lines(src, r_file)
   if (outfile_given) {
     message("Preparing reprex as .R file:\n  * ", r_file)
   }
 
   if (!render) {
-    return(invisible(xfun::read_utf8(r_file, error = FALSE)))
+    return(invisible(read_lines(r_file)))
   }
 
   message("Rendering reprex...")
@@ -328,9 +328,9 @@ reprex <- function(x = NULL,
 
   if (venue %in% c("r", "rtf")) {
     rout_file <- files[["rout_file"]]
-    output_lines <- xfun::read_utf8(md_file)
+    output_lines <- read_lines(md_file)
     output_lines <- convert_md_to_r(output_lines, comment = comment)
-    writeLines(output_lines, rout_file)
+    write_lines(output_lines, rout_file)
     if (outfile_given) {
       message("Writing reprex as commented R script:\n  * ", rout_file)
     }
@@ -377,7 +377,7 @@ reprex <- function(x = NULL,
     viewer(html_file)
   }
 
-  out_lines <- xfun::read_utf8(reprex_file)
+  out_lines <- read_lines(reprex_file)
 
   if (clipboard_available()) {
     clipr::write_clip(out_lines)

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -305,13 +305,13 @@ reprex <- function(x = NULL,
     comment = comment, tidyverse_quiet = tidyverse_quiet, std_file = std_file
   )
   src <- apply_template(src, data)
-  writeLines(src, r_file)
+  xfun::write_utf8(src, r_file)
   if (outfile_given) {
     message("Preparing reprex as .R file:\n  * ", r_file)
   }
 
   if (!render) {
-    return(invisible(readLines(r_file, encoding = "UTF-8")))
+    return(invisible(xfun::read_utf8(r_file, error = FALSE)))
   }
 
   message("Rendering reprex...")
@@ -332,7 +332,7 @@ reprex <- function(x = NULL,
 
   if (venue %in% c("r", "rtf")) {
     rout_file <- files[["rout_file"]]
-    output_lines <- readLines(md_file, encoding = "UTF-8")
+    output_lines <- xfun::read_utf8(md_file)
     output_lines <- convert_md_to_r(
       output_lines, comment = comment, flavor = "fenced"
     )
@@ -383,7 +383,7 @@ reprex <- function(x = NULL,
     viewer(html_file)
   }
 
-  out_lines <- readLines(reprex_file, encoding = "UTF-8")
+  out_lines <- xfun::read_utf8(reprex_file)
 
   if (clipboard_available()) {
     clipr::write_clip(out_lines)

--- a/R/stringify_expression.R
+++ b/R/stringify_expression.R
@@ -8,7 +8,7 @@ stringify_expression <- function(x) {
   .srcref <- utils::getSrcref(x)
 
   if (is.null(.srcref)) {
-    return(deparse(x))
+    return(enc2utf8(deparse(x)))
   }
 
   ## Construct a new srcref with the first_line, first_byte, etc. from the

--- a/R/stringify_expression.R
+++ b/R/stringify_expression.R
@@ -28,7 +28,7 @@ stringify_expression <- function(x) {
     )
   )
 
-  lines <- as.character(src, useSource = TRUE)
+  lines <- enc2utf8(as.character(src, useSource = TRUE))
 
   ## remove the first brace and line if the brace is the only thing on the line
   lines <- sub("^[{]", "", lines)

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ locate_input <- function(input) {
 
 read_lines <- function(path) {
   if (is.null(path)) return(NULL)
-  readLines(path)
+  xfun::read_utf8(path)
 }
 
 trim_ws <- function(x) {
@@ -73,8 +73,8 @@ enfence <- function(lines,
 
 
 inject_file <- function(path, inject_path, pre_process = enfence, ...) {
-  lines <- readLines(path, encoding = "UTF-8")
-  inject_lines <- readLines(inject_path, encoding = "UTF-8")
+  lines <- xfun::read_utf8(path)
+  inject_lines <- xfun::read_utf8(inject_path)
   inject_lines <- pre_process(inject_lines, ...)
 
   inject_locus <- grep(backtick(inject_path), lines, fixed = TRUE)
@@ -83,7 +83,7 @@ inject_file <- function(path, inject_path, pre_process = enfence, ...) {
     inject_lines,
     lines[-seq_len(inject_locus)]
   )
-  writeLines(lines, path)
+  xfun::write_utf8(lines, path)
   path
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,9 +15,13 @@ locate_input <- function(input) {
   }
 }
 
-read_lines <- function(path) {
+read_lines <- function(path, error = FALSE) {
   if (is.null(path)) return(NULL)
-  xfun::read_utf8(path)
+  xfun::read_utf8(path, error = error)
+}
+
+write_lines <- function(text, path) {
+  xfun::write_utf8(text, path)
 }
 
 trim_ws <- function(x) {
@@ -85,8 +89,8 @@ enfence <- function(lines,
 
 
 inject_file <- function(path, inject_path, pre_process = enfence, ...) {
-  lines <- xfun::read_utf8(path)
-  inject_lines <- xfun::read_utf8(inject_path)
+  lines <- read_lines(path)
+  inject_lines <- read_lines(inject_path)
   inject_lines <- pre_process(inject_lines, ...)
 
   inject_locus <- grep(backtick(inject_path), lines, fixed = TRUE)
@@ -95,7 +99,7 @@ inject_file <- function(path, inject_path, pre_process = enfence, ...) {
     inject_lines,
     lines[-seq_len(inject_locus)]
   )
-  xfun::write_utf8(lines, path)
+  write_lines(lines, path)
   path
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,7 @@ install:
 environment:
   global:
     USE_RTOOLS: true
-
-cache:
-  - C:\RLibrary
+    PKGTYPE: binary
 
 # Adapt as necessary starting from here
 before_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
   NOT_CRAN: true
   USE_RTOOLS: true
 
+cache:
+  - C:\RLibrary
+
 # Adapt as necessary starting from here
 before_test:
   - cinst pandoc


### PR DESCRIPTION
from _xfun_, which is a dependency anyway via _rmarkdown_ -> _knitr_. This fixes encoding problems on non-Latin locales.

Was meant to address #234, but can't fix it unfortunately.