### PR TITLE
Explicitly disable crayon

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -386,7 +386,8 @@ reprex_render <- function(input, std_out_err = NULL) {
     function(input) {
       options(
         keep.source = TRUE,
-        rlang_trace_top_env = globalenv()
+        rlang_trace_top_env = globalenv(),
+        crayon.enabled = FALSE
       )
       rmarkdown::render(input, quiet = TRUE, envir = globalenv())
     },


### PR DESCRIPTION
Fixes #238

Same source looks good now:

``` r
f <- function() g()
g <- function() h()
h <- function() rlang::abort("foo")
f()
#> Error: foo
#> Backtrace:
#>     █
#>  1. └─global::f()
#>  2.   └─global::g()
#>  3.     └─global::h()
```

<sup>Created on 2019-01-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>