### PR TITLE
Add html venue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex *development version*
 
+* New venue "html" to render HTML fragments, useful for pasting in sites without markdown but that allow HTML (#236 @cwickham).
+
 * The YAML of reprex's template has been updated in light of the stricter YAML parser used in Pandoc >= 2.2.2.
 
 * `rlang::set_attrs()` has been soft-deprecated and is no longer used internally.

--- a/R/filepaths.R
+++ b/R/filepaths.R
@@ -34,6 +34,7 @@ make_filenames <- function(filebase = "foo", suffix = "reprex") {
     r_file    = path_ext_set(filebase, "R"),
     md_file   = path_ext_set(filebase, "md"),
     rtf_file  = path_ext_set(filebase, "rtf"),
+    html_fragment_file = path_ext_set(add_suffix(filebase, "fragment"), "html"),
     std_file  = path_ext_set(add_suffix(filebase, "std_out_err"), "txt"),
     rout_file = path_ext_set(add_suffix(filebase, "rendered"), "R"),
     html_file = path_ext_set(filebase, "html")

--- a/R/reprex-addin.R
+++ b/R/reprex-addin.R
@@ -66,7 +66,8 @@ reprex_addin <- function() { # nocov start
           "GitHub" = "gh",
           "Stack Overflow" = "so",
           "R script" = "r",
-          "Rich Text Format" = "rtf"
+          "Rich Text Format" = "rtf",
+          "HTML" = "html"
         ),
         selected = getOption("reprex.venue", "gh")
       ),

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -71,10 +71,12 @@
 #' * "rtf" for [Rich Text
 #' Format](https://en.wikipedia.org/wiki/Rich_Text_Format) (not supported for
 #' un-reprexing)
+#' * "html" for an HTML fragment suitable for inclusion in a larger HTML
+#' document (not supported for un-reprexing)
 #' @param advertise Logical. Whether to include a footer that describes when and
 #'   how the reprex was created. If unspecified, the option `reprex.advertise`
 #'   is consulted and, if that is not defined, default is `TRUE` for venues
-#'   `"gh"`, `"so"`, `"ds"`, and `FALSE` for `"r"` and `"rtf"`.
+#'   `"gh"`, `"so"`, `"ds"`, `"html"` and `FALSE` for `"r"` and `"rtf"`.
 #' @param si Logical. Whether to include [devtools::session_info()], if
 #'   available, or [sessionInfo()] at the end of the reprex. When `venue` is
 #'   "gh" or "ds", the session info is wrapped in a collapsible details tag.
@@ -211,6 +213,14 @@
 #' }, venue = "R")
 #' ret
 #'
+#' ## target venue = html
+#' ret <- reprex({
+#'   x <- 1:4
+#'   y <- 2:5
+#'   x + y
+#' }, venue = "html")
+#' ret
+#'
 #' ## include prompt and don't comment the output
 #' ## use this when you want to make your code hard to execute :)
 #' reprex({
@@ -250,7 +260,7 @@ reprex <- function(x = NULL,
   venue <- rtf_requires_highlight(venue)
 
   advertise       <- advertise %||%
-    getOption("reprex.advertise") %||% (venue %in% c("gh", "so"))
+    getOption("reprex.advertise") %||% (venue %in% c("gh", "so", "html"))
   si              <- arg_option(si)
   style           <- arg_option(style)
   show            <- arg_option(show)

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -232,7 +232,7 @@
 #' @export
 reprex <- function(x = NULL,
                    input = NULL, outfile = NULL,
-                   venue = c("gh", "so", "ds", "r", "rtf"),
+                   venue = c("gh", "so", "ds", "r", "rtf", "html"),
 
                    render = TRUE,
 
@@ -340,6 +340,20 @@ reprex <- function(x = NULL,
       message("Writing reprex as highlighted RTF:\n  * ", reprex_file)
     }
     reprex_file <- rtf_file
+  }
+
+  if (venue == "html") {
+    html_fragment_file <- files[["html_fragment_file"]]
+    rmarkdown::render(
+      md_file,
+      output_format = "html_fragment",
+      output_file = html_fragment_file,
+      clean = FALSE,
+      quiet = TRUE,
+      encoding = "UTF-8",
+      output_options = if (pandoc2.0()) list(pandoc_args = "--quiet")
+    )
+    reprex_file <- html_fragment_file
   }
 
   if (show) {

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -346,7 +346,7 @@ reprex <- function(x = NULL,
     html_fragment_file <- files[["html_fragment_file"]]
     rmarkdown::render(
       md_file,
-      output_format = "html_fragment",
+      output_format = rmarkdown::html_fragment(self_contained = FALSE),
       output_file = html_fragment_file,
       clean = FALSE,
       quiet = TRUE,

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -5,7 +5,7 @@
 \title{Render a reprex}
 \usage{
 reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh",
-  "so", "ds", "r", "rtf"), render = TRUE, advertise = NULL,
+  "so", "ds", "r", "rtf", "html"), render = TRUE, advertise = NULL,
   si = opt(FALSE), style = opt(FALSE), show = opt(TRUE),
   comment = opt("#>"), tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE))
@@ -38,6 +38,8 @@ currently just an alias for "gh"!
 \item "r" for a runnable R script, with commented output interleaved
 \item "rtf" for \href{https://en.wikipedia.org/wiki/Rich_Text_Format}{Rich Text Format} (not supported for
 un-reprexing)
+\item "html" for an HTML fragment suitable for inclusion in a larger HTML
+document (not supported for un-reprexing)
 }}
 
 \item{render}{Logical. Whether to call \code{\link[rmarkdown:render]{rmarkdown::render()}} on the templated
@@ -47,7 +49,7 @@ primarily for the sake of internal testing.}
 \item{advertise}{Logical. Whether to include a footer that describes when and
 how the reprex was created. If unspecified, the option \code{reprex.advertise}
 is consulted and, if that is not defined, default is \code{TRUE} for venues
-\code{"gh"}, \code{"so"}, \code{"ds"}, and \code{FALSE} for \code{"r"} and \code{"rtf"}.}
+\code{"gh"}, \code{"so"}, \code{"ds"}, \code{"html"} and \code{FALSE} for \code{"r"} and \code{"rtf"}.}
 
 \item{si}{Logical. Whether to include \code{\link[devtools:session_info]{devtools::session_info()}}, if
 available, or \code{\link[=sessionInfo]{sessionInfo()}} at the end of the reprex. When \code{venue} is
@@ -240,6 +242,14 @@ ret <- reprex({
   y <- 2:5
   x + y
 }, venue = "R")
+ret
+
+## target venue = html
+ret <- reprex({
+  x <- 1:4
+  y <- 2:5
+  x + y
+}, venue = "html")
 ret
 
 ## include prompt and don't comment the output

--- a/man/reprex_addin.Rd
+++ b/man/reprex_addin.Rd
@@ -21,6 +21,8 @@ currently just an alias for "gh"!
 \item "r" for a runnable R script, with commented output interleaved
 \item "rtf" for \href{https://en.wikipedia.org/wiki/Rich_Text_Format}{Rich Text Format} (not supported for
 un-reprexing)
+\item "html" for an HTML fragment suitable for inclusion in a larger HTML
+document (not supported for un-reprexing)
 }}
 }
 \description{

--- a/man/un-reprex.Rd
+++ b/man/un-reprex.Rd
@@ -39,6 +39,8 @@ currently just an alias for "gh"!
 \item "r" for a runnable R script, with commented output interleaved
 \item "rtf" for \href{https://en.wikipedia.org/wiki/Rich_Text_Format}{Rich Text Format} (not supported for
 un-reprexing)
+\item "html" for an HTML fragment suitable for inclusion in a larger HTML
+document (not supported for un-reprexing)
 }}
 
 \item{comment}{regular expression that matches commented output lines}

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -68,3 +68,21 @@ test_that("local image link is not interrupted by hard line break for 'gh'", {
   i <- grep("incredibly-long", out)
   expect_true(grepl("[)]", out[i]))
 })
+
+test_that("venue = 'html' works", {
+  skip_on_cran()
+  input <- c(
+    "#' Hello world",
+    "## comment",
+    "1:5"
+  )
+  output <- c(
+    "<p>Hello world</p>",
+    "<pre class=\"r\"><code>## comment",
+    "1:5",
+    "#&gt; [1] 1 2 3 4 5</code></pre>"
+  )
+  ret <- reprex(input = input, venue = "html", show = FALSE, advertise = FALSE)
+  ret <- ret[nzchar(ret)]
+  expect_identical(ret, output)
+})


### PR DESCRIPTION
Here's an attempt to add the "html" venue per issue #236.

Essentially replicates the generation of the html preview with the addition of `self_contained = FALSE` (to avoid turning the imgur links into inline images).  There might be a better way to avoid generating HTML twice, suggestions welcome.