### PR TITLE
Specify UTF-8 encoding to rmarkdown::render()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     callr (>= 2.0.0),
     clipr (>= 0.4.0),
     fs,
+    knitr (>= 1.23),
     rlang,
     rmarkdown,
     utils,
@@ -40,7 +41,6 @@ Imports:
 Suggests: 
     covr,
     fortunes,
-    knitr,
     miniUI,
     rprojroot,
     rstudioapi,

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ Overflow does not support the collapsible details tag that we use on GitHub for 
 
 * devtools is no longer in Suggests. It is replaced by sessioninfo.
 
+* knitr is now in Imports, so we can require v1.23 or higher, which represents a
+major switch to UTF-8.
+
 # reprex 0.3.0
 
 * The `crayon.enabled` option is explicitly set to `FALSE` when rendering the reprex (#238, #239).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex (development version)
 
+* UTF-8 encoding: Following the lead of knitr, reprex makes explicit use of UTF-8 internally (#237 @krlmlr, #261).
+
 * `venue = "so"` (SO = Stack Overflow) has converged with default `venue = "gh"` (GitHub). As of January 2019, SO [supports CommonMark fenced code blocks](https://meta.stackexchange.com/questions/125148/implement-style-fenced-markdown-code-blocks/322000#322000). The only remaining difference is that Stack
 Overflow does not support the collapsible details tag that we use on GitHub for the session info requested via `si = TRUE` (#231).
 
@@ -7,8 +9,10 @@ Overflow does not support the collapsible details tag that we use on GitHub for 
 
 * devtools is no longer in Suggests. It is replaced by sessioninfo.
 
-* knitr is now in Imports, so we can require v1.23 or higher, which represents a
+* knitr moves from Suggests to Imports (although it was already a hard dependency via rmarkdown), so we can require v1.23 or higher, which represents a
 major switch to UTF-8.
+
+* xfun is a new direct dependency, though it was already an indirect dependency via knitr. Related to UTF-8 enforcement.
 
 # reprex 0.3.0
 

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -407,7 +407,7 @@ reprex_render <- function(input, std_out_err = NULL) {
         rlang_trace_top_env = globalenv(),
         crayon.enabled = FALSE
       )
-      rmarkdown::render(input, quiet = TRUE, envir = globalenv())
+      rmarkdown::render(input, quiet = TRUE, envir = globalenv(), encoding = "UTF-8")
     },
     args = list(input = input),
     spinner = interactive(),


### PR DESCRIPTION
Continuing the encoding work. #237 is a good start but doesn't get it all done.