### PR TITLE
reprex(venue = "jira")

### DIFF
--- a/R/filepaths.R
+++ b/R/filepaths.R
@@ -37,7 +37,8 @@ make_filenames <- function(filebase = "foo", suffix = "reprex") {
     html_fragment_file = path_ext_set(add_suffix(filebase, "fragment"), "html"),
     std_file  = path_ext_set(add_suffix(filebase, "std_out_err"), "txt"),
     rout_file = path_ext_set(add_suffix(filebase, "rendered"), "R"),
-    html_file = path_ext_set(filebase, "html")
+    html_file = path_ext_set(filebase, "html"),
+    jira_file = path_ext_set(add_suffix(filebase, "jira"), "txt")
   )
 }
 

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -441,6 +441,12 @@ reprex_jira <- function(jira_file, md_file) {
   content <- readLines(md_file)
   content <- gsub("^``` r", "{code:r}", content)
   content <- gsub("^```", "{code}", content)
+  content <- gsub(
+    "[reprex package](https://reprex.tidyverse.org)",
+    "[reprex package|https://reprex.tidyverse.org]",
+    content,
+    fixed = TRUE
+  )
   writeLines(content, jira_file)
 }
 

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -5,7 +5,7 @@
 \title{Render a reprex}
 \usage{
 reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh", "r",
-  "rtf", "html", "so", "ds"), render = TRUE, advertise = NULL,
+  "rtf", "html", "so", "ds", "jira"), render = TRUE, advertise = NULL,
   si = opt(FALSE), style = opt(FALSE), show = opt(TRUE),
   comment = opt("#>"), tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE))
@@ -44,6 +44,7 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "jira" for \href{https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=advanced}{Jira}
 }}
 
 \item{render}{Logical. Whether to call \code{\link[rmarkdown:render]{rmarkdown::render()}} on the templated
@@ -53,7 +54,7 @@ primarily for the sake of internal testing.}
 \item{advertise}{Logical. Whether to include a footer that describes when and
 how the reprex was created. If unspecified, the option \code{reprex.advertise}
 is consulted and, if that is not defined, default is \code{TRUE} for venues
-\code{"gh"}, \code{"html"}, \code{"so"}, \code{"ds"} and \code{FALSE} for \code{"r"} and \code{"rtf"}.}
+\code{"gh"}, \code{"html"}, \code{"so"}, \code{"ds"}, \code{"jira"} and \code{FALSE} for \code{"r"} and \code{"rtf"}.}
 
 \item{si}{Logical. Whether to include \code{\link[sessioninfo:session_info]{sessioninfo::session_info()}}, if
 available, or \code{\link[=sessionInfo]{sessionInfo()}} at the end of the reprex. When \code{venue} is

--- a/man/reprex_addin.Rd
+++ b/man/reprex_addin.Rd
@@ -27,6 +27,7 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "jira" for \href{https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=advanced}{Jira}
 }}
 }
 \description{

--- a/man/un-reprex.Rd
+++ b/man/un-reprex.Rd
@@ -45,6 +45,7 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "jira" for \href{https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=advanced}{Jira}
 }}
 
 \item{comment}{regular expression that matches commented output lines}


### PR DESCRIPTION
related to #193 

e.g. https://issues.apache.org/jira/browse/ARROW-3702?focusedCommentId=16859829&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16859829

This essentially just replaces 

````
``` r
# some code
```
````

 with 

````
{code:r}
# some code
{code}
````

in the `md_file` 
 