### PR TITLE
Added plain-md venue

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -77,6 +77,11 @@
 #' * "ds" for Discourse, e.g.,
 #'   [community.rstudio.com](https://community.rstudio.com). Note: this is
 #'   currently just an alias for "gh".
+#' * "plain-md" for simple, plain markdown without the `r` syntax highlighting
+#'   indicator on the opening backticks of fenced code blocks, and without the
+#'   advertising footer; useful anywhere plain simple
+#'   markdown is desired, but particularly useful for pasting inline within
+#'   Slack posts (as opposed to snippets).
 #' @param advertise Logical. Whether to include a footer that describes when and
 #'   how the reprex was created. If unspecified, the option `reprex.advertise`
 #'   is consulted and, if that is not defined, default is `TRUE` for venues
@@ -237,7 +242,7 @@
 #' @export
 reprex <- function(x = NULL,
                    input = NULL, outfile = NULL,
-                   venue = c("gh", "r", "rtf", "html", "so", "ds"),
+                   venue = c("gh", "r", "rtf", "html", "so", "ds", "plain-md"),
 
                    render = TRUE,
 
@@ -257,6 +262,13 @@ reprex <- function(x = NULL,
 
   advertise       <- advertise %||%
     getOption("reprex.advertise") %||% (venue %in% c("gh", "html"))
+
+  remove_md_syntax_indicator <- FALSE
+  if (venue=='plain-md') {
+    remove_md_syntax_indicator <- TRUE
+    venue <- 'gh'
+  }
+
   si              <- arg_option(si)
   style           <- arg_option(style)
   show            <- arg_option(show)
@@ -312,6 +324,13 @@ reprex <- function(x = NULL,
 
   message("Rendering reprex...")
   reprex_render(r_file, std_file)
+
+  if (remove_md_syntax_indicator) {
+    md_lines <- readLines(files[['md_file']])
+    md_lines <- gsub(x=md_lines, pattern='``` r', replacement='```')
+    writeLines(md_lines, files[['md_file']])
+  }
+
   ## 1. when venue = "r" or "rtf", the reprex_file != md_file, so we need both
   ## 2. use our own "md_file" instead of the normalized, absolutized path
   ##    returned by rmarkdown::render() and, therefore, reprex_()

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -5,9 +5,9 @@
 \title{Render a reprex}
 \usage{
 reprex(x = NULL, input = NULL, outfile = NULL, venue = c("gh", "r",
-  "rtf", "html", "so", "ds"), render = TRUE, advertise = NULL,
-  si = opt(FALSE), style = opt(FALSE), show = opt(TRUE),
-  comment = opt("#>"), tidyverse_quiet = opt(TRUE),
+  "rtf", "html", "so", "ds", "plain-md"), render = TRUE,
+  advertise = NULL, si = opt(FALSE), style = opt(FALSE),
+  show = opt(TRUE), comment = opt("#>"), tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE))
 }
 \arguments{
@@ -44,6 +44,11 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "plain-md" for simple, plain markdown without the \code{r} syntax highlighting
+indicator on the opening backticks of fenced code blocks, and without the
+advertising footer; useful anywhere plain simple
+markdown is desired, but particularly useful for pasting inline within
+Slack posts (as opposed to snippets).
 }}
 
 \item{render}{Logical. Whether to call \code{\link[rmarkdown:render]{rmarkdown::render()}} on the templated

--- a/man/reprex_addin.Rd
+++ b/man/reprex_addin.Rd
@@ -27,6 +27,11 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "plain-md" for simple, plain markdown without the \code{r} syntax highlighting
+indicator on the opening backticks of fenced code blocks, and without the
+advertising footer; useful anywhere plain simple
+markdown is desired, but particularly useful for pasting inline within
+Slack posts (as opposed to snippets).
 }}
 }
 \description{

--- a/man/un-reprex.Rd
+++ b/man/un-reprex.Rd
@@ -45,6 +45,11 @@ support CommonMark-style fenced code blocks in January 2019.
 \item "ds" for Discourse, e.g.,
 \href{https://community.rstudio.com}{community.rstudio.com}. Note: this is
 currently just an alias for "gh".
+\item "plain-md" for simple, plain markdown without the \code{r} syntax highlighting
+indicator on the opening backticks of fenced code blocks, and without the
+advertising footer; useful anywhere plain simple
+markdown is desired, but particularly useful for pasting inline within
+Slack posts (as opposed to snippets).
 }}
 
 \item{comment}{regular expression that matches commented output lines}

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -90,3 +90,18 @@ test_that("venue = 'html' works", {
   ret <- ret[nzchar(ret)]
   expect_identical(ret, output)
 })
+
+test_that("venue = 'plain-md' has no md syntax indicator nor ad by default", {
+  skip_on_cran()
+  input <- c(
+    "#' Hello world",
+    "## comment",
+    "1:5"
+  )
+  ret <- reprex(input = input, venue = "plain-md", show = FALSE)
+  expect_equal(sum(grepl(x=ret, pattern='```')), 2)
+  expect_true(!any(grepl(x=ret, pattern='```.+r')))
+  expect_true(!any(grepl(x=ret, pattern='<sup>Created on.+by the.+/sup')))
+  ret <- reprex(input = input, venue = "plain-md", show = FALSE, advertise = TRUE)
+  expect_true(any(grepl(x=ret, pattern='<sup>Created on.+by the.+/sup')))
+})


### PR DESCRIPTION
Useful for posting reprex output inline within Slack posts (when a snippet is overkill), and potentially useful for other purposes as well.