### PR TITLE
require styler 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
     sessioninfo,
     shiny,
     spelling,
-    styler (>= 1.0.2),
+    styler (>= 1.2.0),
     testthat (>= 2.1.0)
 VignetteBuilder: 
     knitr


### PR DESCRIPTION
In particular because {{ is now recognized as rlang *curly curly*. Before, the line was broken between the two curly braces. For details see https://github.com/r-lib/styler/releases/tag/v1.2.0