### PR TITLE
Retain rlang errors / traces

### DIFF
--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -37,7 +37,6 @@ test_that("rmarkdown::render() context is trimmed from rlang backtrace", {
 
 test_that("rlang::last_error() and last_trace() work", {
   skip_on_cran()
-  skip_if_not_installed("rlang", minimum_version = "0.4.3")
 
   input <- c(
     "f <- function() rlang::abort('foo')",
@@ -46,7 +45,10 @@ test_that("rlang::last_error() and last_trace() work", {
     "rlang::last_trace()"
   )
   ret <- reprex(input = input, advertise = FALSE)
-  expect_false(any(grepl("no error was recorded", ret)))
+  m <- match("rlang::last_error()", ret)
+  expect_false(grepl("Error", ret[m + 1]))
+  m <- match("rlang::last_trace()", ret)
+  expect_false(grepl("Error", ret[m + 1]))
 })
 
 test_that("reprex() works even if user uses fancy quotes", {

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -24,14 +24,34 @@ test_that("reprex() doesn't leak files by default", {
 
 test_that("rmarkdown::render() context is trimmed from rlang backtrace", {
   skip_on_cran()
-  input <- "f <- function() g(); g <- function() h(); h <- function() rlang::abort('foo'); f()\n"
+  input <- c(
+    "f <- function() rlang::abort('foo')",
+    "f()",
+    "rlang::last_error()",
+    "rlang::last_trace()"
+  )
   ret <- reprex(input = input, advertise = FALSE)
   expect_false(any(grepl("tryCatch", ret)))
   expect_false(any(grepl("rmarkdown::render", ret)))
 })
 
+test_that("rlang::last_error() and last_trace() work", {
+  skip_on_cran()
+  skip_if_not_installed("rlang", minimum_version = "0.4.3")
+
+  input <- c(
+    "f <- function() rlang::abort('foo')",
+    "f()",
+    "rlang::last_error()",
+    "rlang::last_trace()"
+  )
+  ret <- reprex(input = input, advertise = FALSE)
+  expect_false(any(grepl("no error was recorded", ret)))
+})
+
 test_that("reprex() works even if user uses fancy quotes", {
   skip_on_cran()
   withr::local_options(list(useFancyQuotes = TRUE))
+  # use non-default venue to force some quoted yaml to be written
   expect_error_free(reprex(1, venue = "R"))
 })


### PR DESCRIPTION
Solving this entirely within reprex, using suggestion adapted from https://github.com/r-lib/rlang/issues/894