### PR TITLE
Fix broken link for roxygen markdown formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ You can use the [styler](https://CRAN.R-project.org/package=styler) package to
 apply these styles, but please don't restyle code that has nothing to do with 
 your PR.  
 *  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
-[Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html), 
+[Markdown syntax](https://roxygen2.r-lib.org/articles/rd-formatting.html), 
 for documentation.  
 *  We use [testthat](https://cran.r-project.org/package=testthat). Contributions
 with test cases included are easier to accept.  


### PR DESCRIPTION
Fixing this in CONTRIBUTING across multiple packages (see r-lib/usethis#1126).