### PR TITLE
Quiet tidymodels, similarly to tidyverse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,5 +65,5 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * New article on techniques for making package startup quieter (#187, @marionlouveaux).
 
+*  The `tidyverse_quiet` argument and `reprex.tidyverse_quiet` option also affect startup messages from the [tidymodels](https://www.tidymodels.org) meta-package (#326, @juliasilge).
+
 * `reprex_locale()` is a new thin wrapper around `reprex()` that renders in a temporarily-altered locale (#250).
 
 * UTF-8 encoding: Following the lead of knitr, reprex makes explicit use of UTF-8 internally (#237 @krlmlr, #261).

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -93,9 +93,10 @@
 #' @param render Logical. Whether to call [rmarkdown::render()] on the templated
 #'   reprex, i.e. whether to actually run the code. Defaults to `TRUE`. Exists
 #'   primarily for the sake of internal testing.
-#' @param tidyverse_quiet Logical. Sets the option `tidyverse.quiet`, which
-#'   suppresses (`TRUE`, the default) or includes (`FALSE`) the startup message
-#'   for the tidyverse package. Read more about [opt()].
+#' @param tidyverse_quiet Logical. Sets the options `tidyverse.quiet` and
+#'   `tidymodels.quiet`, which suppress (`TRUE`, the default) or include
+#'   (`FALSE`) the startup messages for the tidyverse and tidymodels packages.
+#'   Read more about [opt()].
 #' @param std_out_err Logical. Whether to append a section for output sent to
 #'   stdout and stderr by the reprex rendering process. This can be necessary to
 #'   reveal output if the reprex spawns child processes or `system()` calls.

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -71,7 +71,7 @@ reprex_document <- function(venue = c("gh", "r", "rtf", "html", "so", "ds"),
     R.options = list(
       tidyverse.quiet = tidyverse_quiet,
       tidymodels.quiet = tidyverse_quiet
-      )
+    )
   )
   if (isTRUE(style)) {
     opts_chunk[["tidy"]] <- "styler"

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -68,7 +68,10 @@ reprex_document <- function(venue = c("gh", "r", "rtf", "html", "so", "ds"),
     collapse = TRUE, error = TRUE,
     # explicitly exposed for user configuration
     comment = comment,
-    R.options = list(tidyverse.quiet = tidyverse_quiet)
+    R.options = list(
+      tidyverse.quiet = tidyverse_quiet,
+      tidymodels.quiet = tidyverse_quiet
+      )
   )
   if (isTRUE(style)) {
     opts_chunk[["tidy"]] <- "styler"

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -78,6 +78,7 @@ SystemRequirements
 templated
 tibble
 tidyeval
+tidymodels
 tidyverse
 Tierney
 Tierney's

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -76,9 +76,10 @@ collapsible details tag. Read more about \code{\link[=opt]{opt()}}.}
 \item{comment}{Character. Prefix with which to comment out output, defaults
 to \code{"#>"}. Read more about \code{\link[=opt]{opt()}}.}
 
-\item{tidyverse_quiet}{Logical. Sets the option \code{tidyverse.quiet}, which
-suppresses (\code{TRUE}, the default) or includes (\code{FALSE}) the startup message
-for the tidyverse package. Read more about \code{\link[=opt]{opt()}}.}
+\item{tidyverse_quiet}{Logical. Sets the options \code{tidyverse.quiet} and
+\code{tidymodels.quiet}, which suppress (\code{TRUE}, the default) or include
+(\code{FALSE}) the startup messages for the tidyverse and tidymodels packages.
+Read more about \code{\link[=opt]{opt()}}.}
 
 \item{std_out_err}{Logical. Whether to append a section for output sent to
 stdout and stderr by the reprex rendering process. This can be necessary to

--- a/man/reprex_document.Rd
+++ b/man/reprex_document.Rd
@@ -51,9 +51,10 @@ collapsible details tag. Read more about \code{\link[=opt]{opt()}}.}
 \item{comment}{Character. Prefix with which to comment out output, defaults
 to \code{"#>"}. Read more about \code{\link[=opt]{opt()}}.}
 
-\item{tidyverse_quiet}{Logical. Sets the option \code{tidyverse.quiet}, which
-suppresses (\code{TRUE}, the default) or includes (\code{FALSE}) the startup message
-for the tidyverse package. Read more about \code{\link[=opt]{opt()}}.}
+\item{tidyverse_quiet}{Logical. Sets the options \code{tidyverse.quiet} and
+\code{tidymodels.quiet}, which suppress (\code{TRUE}, the default) or include
+(\code{FALSE}) the startup messages for the tidyverse and tidymodels packages.
+Read more about \code{\link[=opt]{opt()}}.}
 
 \item{std_out_err}{Logical. Whether to append a section for output sent to
 stdout and stderr by the reprex rendering process. This can be necessary to

--- a/tests/testthat/test-knitr-options.R
+++ b/tests/testthat/test-knitr-options.R
@@ -26,6 +26,11 @@ test_that("`tidyverse_quiet` works", {
     tidyverse_quiet = FALSE
   )
   expect_match(ret, "Attaching", all = FALSE)
+})
+
+test_that("`tidyverse_quiet` works for tidymodels", {
+  skip_on_cran()
+  skip_if_not_installed("tidymodels")
 
   ret <- reprex(
     input = sprintf("library(%s)\n", "tidymodels"),
@@ -40,6 +45,7 @@ test_that("`tidyverse_quiet` works", {
   expect_match(ret, "Attaching", all = FALSE)
 
 })
+
 
 test_that("`style` works", {
   skip_on_cran()

--- a/tests/testthat/test-knitr-options.R
+++ b/tests/testthat/test-knitr-options.R
@@ -16,13 +16,13 @@ test_that("`tidyverse_quiet` works", {
   skip_if_not_installed("tidyverse", minimum_version = "1.2.1")
 
   ret <- reprex(
-    input = sprintf("library(%s)\n", "tidyverse"),
+    input = "library(tidyverse)\n",
     tidyverse_quiet = TRUE
   )
   expect_false(any(grepl("Attaching", ret)))
 
   ret <- reprex(
-    input = sprintf("library(%s)\n", "tidyverse"),
+    input = "library(tidyverse)\n",
     tidyverse_quiet = FALSE
   )
   expect_match(ret, "Attaching", all = FALSE)
@@ -33,13 +33,13 @@ test_that("`tidyverse_quiet` works for tidymodels", {
   skip_if_not_installed("tidymodels")
 
   ret <- reprex(
-    input = sprintf("library(%s)\n", "tidymodels"),
+    input = "library(tidymodels)\n",
     tidyverse_quiet = TRUE
   )
   expect_false(any(grepl("Attaching", ret)))
 
   ret <- reprex(
-    input = sprintf("library(%s)\n", "tidymodels"),
+    input = "library(tidymodels)\n",
     tidyverse_quiet = FALSE
   )
   expect_match(ret, "Attaching", all = FALSE)

--- a/tests/testthat/test-knitr-options.R
+++ b/tests/testthat/test-knitr-options.R
@@ -26,6 +26,19 @@ test_that("`tidyverse_quiet` works", {
     tidyverse_quiet = FALSE
   )
   expect_match(ret, "Attaching", all = FALSE)
+
+  ret <- reprex(
+    input = sprintf("library(%s)\n", "tidymodels"),
+    tidyverse_quiet = TRUE
+  )
+  expect_false(any(grepl("Attaching", ret)))
+
+  ret <- reprex(
+    input = sprintf("library(%s)\n", "tidymodels"),
+    tidyverse_quiet = FALSE
+  )
+  expect_match(ret, "Attaching", all = FALSE)
+
 })
 
 test_that("`style` works", {

--- a/vignettes/articles/suppress-startup-messages.Rmd
+++ b/vignettes/articles/suppress-startup-messages.Rmd
@@ -52,6 +52,8 @@ library(tidyverse)
 slice(iris, 1)
 ```
 
+`tidyverse_quiet` also silences startup messages from the [tidymodels](https://www.tidymodels.org) meta-package.
+
 ## dplyr is chatty at startup
 
 dplyr is a common culprit for noisy startup, so we use it as an example. Note this messaging as a baseline.
@@ -136,4 +138,4 @@ suppressPackageStartupMessages(library(dplyr))
 slice(iris, 1)
 ```
 
-Note that this default behaviour can be overridden by setting `tidyverse_quiet = FALSE` in a specific `reprex()` call or by setting the option `reprex.tidyverse_quiet = FALSE` in the `.Rprofile` startup file.
+Note that this default behaviour can be overridden by setting `tidyverse_quiet = FALSE` in a specific `reprex()` call or by setting the option `reprex.tidyverse_quiet = FALSE` in the `.Rprofile` startup file. The `tidyverse_quiet` argument and `reprex.tidyverse_quiet` option also affect startup messages from the [tidymodels](https://www.tidymodels.org) meta-package.


### PR DESCRIPTION
This PR closes #326 by controling the `tidymodels.quiet` option from tidymodels with the reprex option `tidyverse_option`, similar to how tidyverse is quieted.

``` r
library(tidyverse)
library(tidymodels)
```

<sup>Created on 2020-08-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

I set the test to skip when tidymodels is not installed, because I am confident you do not want to deal with installing tidymodels on CI for this package.
