### PR TITLE
Fix highlight on windows.

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -1,6 +1,6 @@
 reprex_highlight <- function(rout_file, reprex_file, arg_string = NULL) {
   arg_string <- arg_string %||% highlight_args()
-  out <- ifelse(Platform$OS.type == "windows", " -o ", " > ")
+  out <- ifelse(.Platform$OS.type == "windows", " -o ", " > ")
   cmd <- paste0(
     "highlight ", rout_file,
     " --out-format=rtf --no-trailing-nl --encoding=UTF-8",

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -1,10 +1,11 @@
 reprex_highlight <- function(rout_file, reprex_file, arg_string = NULL) {
   arg_string <- arg_string %||% highlight_args()
+  out <- ifelse(Platform$OS.type == "windows", " -o ", " > ")
   cmd <- paste0(
     "highlight ", rout_file,
     " --out-format=rtf --no-trailing-nl --encoding=UTF-8",
     arg_string,
-    " > ", reprex_file
+    out, reprex_file
   )
   res <- system(cmd)
   if (res > 0) {

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -1,11 +1,10 @@
 reprex_highlight <- function(rout_file, reprex_file, arg_string = NULL) {
   arg_string <- arg_string %||% highlight_args()
-  out <- ifelse(.Platform$OS.type == "windows", " -o ", " > ")
   cmd <- paste0(
     "highlight ", rout_file,
     " --out-format=rtf --no-trailing-nl --encoding=UTF-8",
     arg_string,
-    out, reprex_file
+    " -o ", reprex_file
   )
   res <- system(cmd)
   if (res > 0) {


### PR DESCRIPTION
Part of #331 

`reprex(venue = "rtf")` works now but I am not sure if the result is as intended. On the clipboard is raw rtf which can not be pasted into PowerPoint etc. to create the expected highlighted reprex but rather looks like this:
```
{\rtf1\ansi \deff1{\fonttbl{\f1\fmodern\fprq1\fcharset0 Courier Regular;}}{\colortbl;\red00\green00\blue00;\red160\green160\blue192;\red208\green224\blue128;\red208\green224\blue128;\red96\green96\blue128;\red96\green96\blue128;\red128\green128\blue128;\red160\green160\blue192;\red208\green224\blue128;\red96\green96\blue128;\red204\green204\blue204;\red207\green165\blue219;\red128\green144\blue240;\red224\green224\blue255;\red159\green191\blue175;}
```
I am not sure if this is due to differences in how Windows and *nix handle the clipboard as I have no experience with R on other platforms. A workaround to be able to use reprex for email, presentations etc. is to just copy the reprex from the viewer, formatting will be copied as well.