### PR TITLE
Use testthat 3e and classed messages (that can be turned off/on)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
     shiny,
     spelling,
     styler (>= 1.2.0),
-    testthat (>= 2.1.0)
+    testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
@@ -67,3 +67,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
+Config/testthat/edition: 3

--- a/R/ensure.R
+++ b/R/ensure.R
@@ -58,8 +58,7 @@ ensure_no_prompts <- function(x, prompt = getOption("prompt")) {
   regex <- paste0("^", escape_regex(prompt))
   prompts <- grepl(regex, x)
   if (any(prompts)) {
-    message("Removing leading prompts from reprex source.")
+    reprex_inform("Removing leading prompts from reprex source.")
   }
   sub(regex, "", x)
 }
-

--- a/R/reprex-undo.R
+++ b/R/reprex-undo.R
@@ -180,11 +180,11 @@ reprex_undo <- function(input = NULL,
 
   if (clipboard_available()) {
     clipr::write_clip(x_out)
-    message("Clean code is on the clipboard.")
+    reprex_inform("Clean code is on the clipboard.")
   }
   if (outfile_given) {
     write_lines(x_out, r_file)
-    message("Writing clean code as R script:\n  * ", r_file)
+    reprex_inform(c("Writing clean code as R script:", r_file))
   }
   invisible(x_out)
 }

--- a/R/reprex_impl.R
+++ b/R/reprex_impl.R
@@ -65,14 +65,14 @@ reprex_impl <- function(x_expr = NULL,
   src <- c(yamlify(reprex_document_options), "", src)
   write_lines(src, r_file)
   if (outfile_given) {
-    message("Preparing reprex as .R file:\n  * ", r_file)
+    reprex_inform(c("Preparing reprex as .R file:", r_file))
   }
 
   if (!render) {
     return(invisible(read_lines(r_file)))
   }
 
-  message("Rendering reprex...")
+  reprex_inform("Rendering reprex...")
   reprex_file <- reprex_render_impl(r_file, new_session = new_session)
   # for reasons re: the RStudio "Knit" button, reprex_render_impl() may return
   # path to the html_preview, but reprex_file attribute will always be the
@@ -81,7 +81,7 @@ reprex_impl <- function(x_expr = NULL,
   reprex_file <- attr(reprex_file, "reprex_file", exact = TRUE)
 
   if (outfile_given) {
-    message("Writing reprex file:\n  * ", reprex_file)
+    reprex_inform(c("Writing reprex file:", reprex_file))
   }
 
   out_lines <- read_lines(reprex_file)
@@ -92,16 +92,15 @@ reprex_impl <- function(x_expr = NULL,
     } else {
       clipr::write_clip(out_lines)
     }
-    message("Rendered reprex is on the clipboard.")
+    reprex_inform("Rendered reprex is on the clipboard.")
   } else if (is_interactive()) {
     clipr::dr_clipr()
-    message(
-      "Unable to put result on the clipboard. How to get it:\n",
-      "  * Capture what `reprex()` returns.\n",
-      "  * Consult the output file. Control via `outfile` argument.\n",
-      "Path to `outfile`:\n",
-      "  * ", reprex_file
-    )
+    reprex_inform(c(
+      "Unable to put result on the clipboard. How to get it:",
+      "Capture what `reprex()` returns.",
+      "Consult the output file. Control via `outfile` argument.",
+      glue::glue("Path to `outfile`: {reprex_file}")
+    ))
     if (yep("Open the output file for manual copy?")) {
       withr::defer(utils::file.edit(reprex_file))
     }
@@ -119,7 +118,7 @@ set_advertise <- function(advertise, venue) {
 
 style_requires_styler <- function(style) {
   if (!requireNamespace("styler", quietly = TRUE)) {
-    message("Install the styler package in order to use `style = TRUE`.")
+    reprex_inform("Install the styler package in order to use `style = TRUE`.")
     style <- FALSE
   }
   invisible(style)
@@ -127,7 +126,7 @@ style_requires_styler <- function(style) {
 
 html_preview_requires_interactive <- function(html_preview) {
   if (html_preview && !is_interactive()) {
-    message("Non-interactive session, setting `html_preview = FALSE`.")
+    reprex_inform("Non-interactive session, setting `html_preview = FALSE`.")
     html_preview <- FALSE
   }
   invisible(html_preview)
@@ -166,11 +165,10 @@ remove_defaults <- function(x) {
 
   novel_names <- setdiff(names(x), names(defaults))
   if (length(novel_names) > 0) {
-    novel_names <- glue::glue_collapse(novel_names, sep = ", ")
-    message(
-      "These parameter(s) are not recognized for the `reprex_document()` format:\n",
+    reprex_inform(c(
+      "These parameter(s) are not recognized for the `reprex_document()` format:",
       novel_names
-    )
+    ))
   }
 
   x[!is_default]

--- a/R/reprex_impl.R
+++ b/R/reprex_impl.R
@@ -99,7 +99,7 @@ reprex_impl <- function(x_expr = NULL,
       "Unable to put result on the clipboard. How to get it:",
       "Capture what `reprex()` returns.",
       "Consult the output file. Control via `outfile` argument.",
-      glue::glue("Path to `outfile`: {reprex_file}")
+      "Path to `outfile`: {reprex_file}"
     ))
     if (yep("Open the output file for manual copy?")) {
       withr::defer(utils::file.edit(reprex_file))

--- a/R/reprex_inform.R
+++ b/R/reprex_inform.R
@@ -15,8 +15,6 @@ reprex_inform <- function(message) {
   }
 }
 
-
-
 message <- function(...) {
   stop("Internal error: use reprex_inform() instead of message()")
 }

--- a/R/reprex_inform.R
+++ b/R/reprex_inform.R
@@ -16,5 +16,5 @@ reprex_inform <- function(message) {
 }
 
 message <- function(...) {
-  stop("Internal error: use reprex_inform() instead of message()")
+  abort("Internal error: use reprex_inform() instead of message()")
 }

--- a/R/reprex_inform.R
+++ b/R/reprex_inform.R
@@ -6,6 +6,10 @@ local_reprex_quiet <- function(reprex_quiet, env = parent.frame()) {
   withr::local_envvar(c(REPREX_QUIET = reprex_quiet), .local_envir = env)
 }
 
+local_reprex_loud <- function(env = parent.frame()) {
+  local_reprex_quiet("FALSE", env = env)
+}
+
 reprex_inform <- function(message) {
   quiet <- reprex_quiet() %|% is_testing()
   if (quiet) {

--- a/R/reprex_inform.R
+++ b/R/reprex_inform.R
@@ -1,0 +1,22 @@
+reprex_quiet <- function() {
+  as.logical(Sys.getenv("REPREX_QUIET", unset = "NA"))
+}
+
+local_reprex_quiet <- function(reprex_quiet, env = parent.frame()) {
+  withr::local_envvar(c(REPREX_QUIET = reprex_quiet), .local_envir = env)
+}
+
+reprex_inform <- function(message) {
+  quiet <- reprex_quiet() %|% is_testing()
+  if (quiet) {
+    invisible()
+  } else {
+    inform(message, class = "reprex_message")
+  }
+}
+
+
+
+message <- function(...) {
+  stop("Internal error: use reprex_inform() instead of message()")
+}

--- a/R/reprex_inform.R
+++ b/R/reprex_inform.R
@@ -10,15 +10,23 @@ local_reprex_loud <- function(env = parent.frame()) {
   local_reprex_quiet("FALSE", env = env)
 }
 
-reprex_inform <- function(message) {
+reprex_inform <- function(message, .env = parent.frame()) {
   quiet <- reprex_quiet() %|% is_testing()
   if (quiet) {
     invisible()
   } else {
+    g <- function(x) glue::glue(x, .envir = .env)
+    message <- map_chr(message, g)
     inform(message, class = "reprex_message")
   }
 }
 
 message <- function(...) {
-  abort("Internal error: use reprex_inform() instead of message()")
+  abort("Internal error: use `reprex_inform()` instead of `message()`")
+}
+
+map_chr <- function(.x, .f, ...) {
+  out <- vapply(.x, .f, character(1), ..., USE.NAMES = FALSE)
+  names(out) <- names(.x)
+  out
 }

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -216,7 +216,7 @@ inject_file <- function(path, inject_path) {
 
   # a user should never see this, but it can happen during development
   if (length(inject_locus) > 1) {
-    message("multiple placeholders for std_out_err! taking the last")
+    reprex_inform("multiple placeholders for std_out_err! taking the last")
     inject_locus <- inject_locus[length(inject_locus)]
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,7 +37,7 @@ ingest_clipboard <- function() {
       enc2utf8(clipr::read_clip() %||% character())
     ))
   }
-  message("No input provided and clipboard is not available.")
+  reprex_inform("No input provided and clipboard is not available.")
   character()
 }
 
@@ -52,7 +52,7 @@ write_clip_windows_rtf <- function(path) {
   res <- system(cmd)
   if (res > 0) {
     #stop("Failed to put RTF on the Windows clipboard", call. = FALSE)
-    message("Failed to put RTF on the Windows clipboard :(")
+    reprex_inform("Failed to put RTF on the Windows clipboard :(")
     invisible(FALSE)
   } else {
     invisible(TRUE)
@@ -79,3 +79,7 @@ r_chunk <- function(code, label = NULL) {
 backtick <- function(x) encodeString(x, quote = "`")
 
 newline <- function(x) paste0(x, "\n")
+
+is_testing <- function() {
+  identical(Sys.getenv("TESTTHAT"), "true")
+}

--- a/R/venues.R
+++ b/R/venues.R
@@ -39,10 +39,9 @@ normalize_venue <- function(venue) {
 
 ds_is_gh <- function(venue) {
   if (venue == "ds") {
-    message(
-      "FYI, the Discourse venue \"ds\" is currently an alias for the ",
-      "default GitHub venue \"gh\".\nYou don't need to specify it."
-    )
+    reprex_inform(glue::glue('
+      The Discourse venue "ds" is an alias for the default GitHub venue "gh".
+      There is no need to specify the venue.'))
     venue <- "gh"
   }
   venue
@@ -50,11 +49,9 @@ ds_is_gh <- function(venue) {
 
 so_is_gh <- function(venue) {
   if (venue == "so") {
-    message(
-      "FYI, the Stack Overflow venue \"so\" is no longer necessary. Due to ",
-      "changes at\nStack Overflow, the markdown produced by the default GitHub ",
-      "venue \"gh\" works in\nboth places. You don't need to specify it."
-    )
+    reprex_inform(glue::glue('
+      The Stack Overflow venue "so" is an alias for the default GitHub venue "gh".
+      There is no need to specify the venue.'))
     venue <- "gh"
   }
   venue

--- a/R/venues.R
+++ b/R/venues.R
@@ -39,9 +39,9 @@ normalize_venue <- function(venue) {
 
 ds_is_gh <- function(venue) {
   if (venue == "ds") {
-    reprex_inform(glue::glue('
+    reprex_inform('
       The Discourse venue "ds" is an alias for the default GitHub venue "gh".
-      There is no need to specify the venue.'))
+      There is no need to specify the venue.')
     venue <- "gh"
   }
   venue
@@ -49,9 +49,9 @@ ds_is_gh <- function(venue) {
 
 so_is_gh <- function(venue) {
   if (venue == "so") {
-    reprex_inform(glue::glue('
+    reprex_inform('
       The Stack Overflow venue "so" is an alias for the default GitHub venue "gh".
-      There is no need to specify the venue.'))
+      There is no need to specify the venue.')
     venue <- "gh"
   }
   venue

--- a/tests/testthat/_snaps/input.md
+++ b/tests/testthat/_snaps/input.md
@@ -1,0 +1,7 @@
+# Leading prompts are removed
+
+    Code
+      res2 <- reprex(input = input2, render = FALSE, html_preview = FALSE)
+    Message <reprex_message>
+      Removing leading prompts from reprex source.
+

--- a/tests/testthat/_snaps/reprex.md
+++ b/tests/testthat/_snaps/reprex.md
@@ -1,0 +1,9 @@
+# reprex() works with code that deals with srcrefs
+
+    [1] "``` r"                                                    
+    [2] "utils::getParseData(parse(text = 'a'))"                   
+    [3] "#>   line1 col1 line2 col2 id parent  token terminal text"
+    [4] "#> 1     1    1     1    1  1      3 SYMBOL     TRUE    a"
+    [5] "#> 3     1    1     1    1  3      0   expr    FALSE"     
+    [6] "```"                                                      
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -8,7 +8,7 @@ expect_error_free <- function(...) {
 #    - restore original working directory
 #    - delete the directory
 local_temp_wd <- function(pattern = "reprextests",
-                                env = parent.frame()) {
+                          env = parent.frame()) {
 
   tmp <- withr::local_tempdir(pattern = pattern, .local_envir = env)
   withr::local_dir(tmp, .local_envir = env)

--- a/tests/testthat/reference/srcref_reprex
+++ b/tests/testthat/reference/srcref_reprex
@@ -1,6 +1,0 @@
-[1] "``` r"                                                    
-[2] "utils::getParseData(parse(text = 'a'))"                   
-[3] "#>   line1 col1 line2 col2 id parent  token terminal text"
-[4] "#> 1     1    1     1    1  1      3 SYMBOL     TRUE    a"
-[5] "#> 3     1    1     1    1  3      0   expr    FALSE"     
-[6] "```"                                                      

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -63,7 +63,7 @@ test_that("Leading prompts are removed", {
   res <- reprex(input = input, render = FALSE)
   input2 <- paste0(getOption("prompt"), input)
 
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
   expect_snapshot(
     res2 <- reprex(input = input2, render = FALSE, html_preview = FALSE),
   )

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -62,9 +62,10 @@ test_that("Leading prompts are removed", {
   input <- c("x <- 1:3", "median(x)")
   res <- reprex(input = input, render = FALSE)
   input2 <- paste0(getOption("prompt"), input)
-  expect_message(
-    res2 <- reprex(input = input2, render = FALSE),
-    "Removing leading prompts"
+
+  local_reprex_quiet(FALSE)
+  expect_snapshot(
+    res2 <- reprex(input = input2, render = FALSE, html_preview = FALSE),
   )
   expect_identical(res, res2)
 })

--- a/tests/testthat/test-outfiles.R
+++ b/tests/testthat/test-outfiles.R
@@ -9,7 +9,7 @@ expect_messages_to_include <- function(haystack, needles) {
 test_that("expected outfiles are written and messaged, venue = 'gh'", {
   skip_on_cran()
   local_temp_wd()
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
 
   msg <- capture_messages(
     ret <- reprex(1:5, outfile = "foo")
@@ -27,7 +27,7 @@ test_that("expected outfiles are written and messaged, venue = 'gh'", {
 test_that("expected outfiles are written and messaged, venue = 'R'", {
   skip_on_cran()
   local_temp_wd()
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
 
   msg <- capture_messages(
     ret <- reprex(1:5, outfile = "foo", venue = "R")
@@ -64,7 +64,7 @@ test_that(".R outfile doesn't clobber .R infile", {
 test_that("outfiles in a subdirectory works", {
   skip_on_cran()
   local_temp_wd()
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
 
   dir_create("foo")
   msg <- capture_messages(
@@ -81,7 +81,7 @@ test_that("outfiles in a subdirectory works", {
 test_that("outfiles based on input file", {
   skip_on_cran()
   local_temp_wd()
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
 
   write_lines("1:5", "foo.R")
   msg <- capture_messages(
@@ -99,7 +99,7 @@ test_that("outfiles based on input file", {
 test_that("outfiles based on tempfile()", {
   skip_on_cran()
   local_temp_wd()
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
 
   msg <- capture_messages(
     ret <- reprex(input = c("x <- 1:3", "min(x)"), outfile = NA)

--- a/tests/testthat/test-outfiles.R
+++ b/tests/testthat/test-outfiles.R
@@ -9,6 +9,7 @@ expect_messages_to_include <- function(haystack, needles) {
 test_that("expected outfiles are written and messaged, venue = 'gh'", {
   skip_on_cran()
   local_temp_wd()
+  local_reprex_quiet(FALSE)
 
   msg <- capture_messages(
     ret <- reprex(1:5, outfile = "foo")
@@ -26,6 +27,7 @@ test_that("expected outfiles are written and messaged, venue = 'gh'", {
 test_that("expected outfiles are written and messaged, venue = 'R'", {
   skip_on_cran()
   local_temp_wd()
+  local_reprex_quiet(FALSE)
 
   msg <- capture_messages(
     ret <- reprex(1:5, outfile = "foo", venue = "R")
@@ -62,6 +64,7 @@ test_that(".R outfile doesn't clobber .R infile", {
 test_that("outfiles in a subdirectory works", {
   skip_on_cran()
   local_temp_wd()
+  local_reprex_quiet(FALSE)
 
   dir_create("foo")
   msg <- capture_messages(
@@ -78,6 +81,7 @@ test_that("outfiles in a subdirectory works", {
 test_that("outfiles based on input file", {
   skip_on_cran()
   local_temp_wd()
+  local_reprex_quiet(FALSE)
 
   write_lines("1:5", "foo.R")
   msg <- capture_messages(
@@ -95,6 +99,7 @@ test_that("outfiles based on input file", {
 test_that("outfiles based on tempfile()", {
   skip_on_cran()
   local_temp_wd()
+  local_reprex_quiet(FALSE)
 
   msg <- capture_messages(
     ret <- reprex(input = c("x <- 1:3", "min(x)"), outfile = NA)

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -11,7 +11,7 @@ test_that("reprex() works with code that deals with srcrefs", {
     input = "utils::getParseData(parse(text = 'a'))\n",
     advertise = FALSE
   )
-  expect_known_output(print(ret), test_path("reference/srcref_reprex"))
+  expect_snapshot_output(print(ret))
 })
 
 ## https://github.com/tidyverse/reprex/issues/183

--- a/tests/testthat/test-reprex_inform.R
+++ b/tests/testthat/test-reprex_inform.R
@@ -1,0 +1,16 @@
+test_that("reprex_inform() is under the control of REPREX_QUIET env var", {
+  local_reprex_quiet(TRUE)
+  expect_message(reprex_inform("blah"), regexp = NA)
+
+  local_reprex_quiet(FALSE)
+  expect_message(reprex_inform("blah"), regexp = "blah")
+})
+
+test_that("reprex_inform() emits a classed condition", {
+  local_reprex_quiet(FALSE)
+  expect_message(reprex_inform("blah"), class = "reprex_message")
+})
+
+test_that("reprex_quiet() defaults to NA", {
+  expect_true(is.na(reprex_quiet()))
+})

--- a/tests/testthat/test-reprex_inform.R
+++ b/tests/testthat/test-reprex_inform.R
@@ -2,12 +2,12 @@ test_that("reprex_inform() is under the control of REPREX_QUIET env var", {
   local_reprex_quiet(TRUE)
   expect_message(reprex_inform("blah"), regexp = NA)
 
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
   expect_message(reprex_inform("blah"), regexp = "blah")
 })
 
 test_that("reprex_inform() emits a classed condition", {
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
   expect_message(reprex_inform("blah"), class = "reprex_message")
 })
 

--- a/tests/testthat/test-undo.R
+++ b/tests/testthat/test-undo.R
@@ -116,7 +116,7 @@ test_that("reprex_invert() can name its own outfile", {
   code <- c("x <- 1:3", "median(x)")
   invert_me <- reprex(input = code, advertise = FALSE)
 
-  local_reprex_quiet(FALSE)
+  local_reprex_loud()
   msg <- capture_messages(
     out <- reprex_invert(input = invert_me, outfile = NA)
   )

--- a/tests/testthat/test-undo.R
+++ b/tests/testthat/test-undo.R
@@ -115,6 +115,8 @@ test_that("reprex_invert() can name its own outfile", {
 
   code <- c("x <- 1:3", "median(x)")
   invert_me <- reprex(input = code, advertise = FALSE)
+
+  local_reprex_quiet(FALSE)
   msg <- capture_messages(
     out <- reprex_invert(input = invert_me, outfile = NA)
   )


### PR DESCRIPTION
Closes #343 

Adapting discussion in https://github.com/tidyverse/design/issues/42#issuecomment-657740145 to where reprex sits in the ecosystem (meaning: intended for direct, interactive use).