### PR TITLE
Account for callr:r()'s handling of .Rprofile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,18 @@ Specifically, this applies to use on RStudio Server and RStudio Cloud.
 * In this context, the file containing the rendered reprex is opened so the
   user can do a manual "copy".
 
+## `.Rprofile`
+
+`reprex()` renders the reprex in a separate, fresh R session using `callr:r()`.
+As of callr 3.4.0 (released 2019-12-09), the default is `callr::r(..., user_profile = "project")`, which means that callr executes a `.Rprofile` found in current working directory.
+Most reprexes happen in a temp directory and there will be no such `.Rprofile`.
+But if the user intentionally reprexes in, e.g., an existing project with a `.Rprofile`, `callr::r()` and therefore `reprex()` honor it.
+In this version of reprex:
+
+* We explicitly make sure that the working directory of the `callr::r()` call is the same as the intended working directory of the reprex.
+* We alert the user that a local `.Rprofile` has been found.
+* We indicate the usage of a local `.Rprofile` in the rendered reprex.
+
 ## Dependency changes
 
 * rstudioapi moves from Suggests to Imports. Related to improving the experience when reprex cannot access the user's clipboard.

--- a/R/reprex_impl.R
+++ b/R/reprex_impl.R
@@ -73,6 +73,15 @@ reprex_impl <- function(x_expr = NULL,
     return(invisible(read_lines(r_file)))
   }
 
+  local_rprofile <- path(path_dir(path_real(r_file)), ".Rprofile")
+  if (file_exists(local_rprofile)) {
+    reprex_path(
+      "Local {.code .Rprofile} detected in reprex directory:",
+      local_rprofile,
+      type = "warning"
+    )
+   }
+
   reprex_info("Rendering reprex...")
   reprex_file <- reprex_render_impl(r_file, new_session = new_session)
   # for reasons re: the RStudio "Knit" button, reprex_render_impl() may return

--- a/tests/testthat/_snaps/rprofile.md
+++ b/tests/testthat/_snaps/rprofile.md
@@ -1,0 +1,18 @@
+# local .Rprofile reporting responds to venue
+
+    Code
+      rprofile_alert("gh")
+    Output
+      [1] "```{r, results = 'asis', echo = FALSE, include = file.exists('.Rprofile'), eval = file.exists('.Rprofile')}"
+      [2] "cat(sprintf(\"*Local `.Rprofile` detected at `%s`*\", normalizePath(\".Rprofile\")))"                       
+      [3] "```"                                                                                                        
+
+---
+
+    Code
+      rprofile_alert("r")
+    Output
+      [1] "```{r, results = 'asis', echo = FALSE, include = file.exists('.Rprofile'), eval = file.exists('.Rprofile')}"
+      [2] "cat(sprintf(\"Local .Rprofile detected at %s\", normalizePath(\".Rprofile\")))"                             
+      [3] "```"                                                                                                        
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -2,6 +2,14 @@ expect_error_free <- function(...) {
   expect_error(..., regexp = NA)
 }
 
+expect_messages_to_include <- function(haystack, needles) {
+  lapply(
+    needles,
+    function(x) expect_match(haystack, x, all = FALSE)
+  )
+  invisible()
+}
+
 with_mock <- function(..., .parent = parent.frame()) {
   mockr::with_mock(..., .parent = .parent, .env = "reprex")
 }

--- a/tests/testthat/test-outfiles.R
+++ b/tests/testthat/test-outfiles.R
@@ -1,11 +1,3 @@
-expect_messages_to_include <- function(haystack, needles) {
-  lapply(
-    needles,
-    function(x) expect_match(haystack, x, all = FALSE)
-  )
-  invisible()
-}
-
 test_that("expected outfiles are written and messaged, venue = 'gh'", {
   skip_on_cran()
   local_temp_wd()

--- a/tests/testthat/test-rprofile.R
+++ b/tests/testthat/test-rprofile.R
@@ -13,3 +13,15 @@ test_that(".Rprofile local to reprex target directory is consulted", {
   out <- reprex(input = aaa_foo, outfile = NA, advertise = FALSE)
   expect_match(out, "aaa", all = FALSE)
 })
+
+test_that("local .Rprofile reporting responds to venue", {
+  expect_snapshot(rprofile_alert("gh"))
+  expect_snapshot(rprofile_alert("r"))
+})
+
+test_that("local .Rprofile is reported", {
+  local_temp_wd()
+  cat("x <- 'aaa'\n", file = ".Rprofile")
+  out <- reprex(x, outfile = NA, advertise = FALSE)
+  expect_match(out, "Local `.Rprofile` detected", fixed = TRUE, all = FALSE)
+})

--- a/tests/testthat/test-rprofile.R
+++ b/tests/testthat/test-rprofile.R
@@ -1,0 +1,15 @@
+test_that(".Rprofile local to reprex target directory is consulted", {
+  local_temp_wd("reprextests-aaa")
+  cat("x <- 'aaa'\n", file = ".Rprofile")
+  cat("x\n", file = "foo.R")
+  aaa_foo <- path_abs("foo.R")
+
+  local_temp_wd("reprextests-bbb")
+  cat("x <- 'bbb'\n", file = ".Rprofile")
+
+  out <- reprex(x, outfile = NA, advertise = FALSE)
+  expect_match(out, "bbb", all = FALSE)
+
+  out <- reprex(input = aaa_foo, outfile = NA, advertise = FALSE)
+  expect_match(out, "aaa", all = FALSE)
+})

--- a/tests/testthat/test-rprofile.R
+++ b/tests/testthat/test-rprofile.R
@@ -1,17 +1,31 @@
-test_that(".Rprofile local to reprex target directory is consulted", {
-  local_temp_wd("reprextests-aaa")
+test_that(".Rprofile local to reprex target directory is consulted & messaged", {
+  local_reprex_loud()
+
+  local_temp_wd("reprextests-aaa-")
   cat("x <- 'aaa'\n", file = ".Rprofile")
   cat("x\n", file = "foo.R")
   aaa_foo <- path_abs("foo.R")
 
-  local_temp_wd("reprextests-bbb")
+  local_temp_wd("reprextests-bbb-")
   cat("x <- 'bbb'\n", file = ".Rprofile")
 
-  out <- reprex(x, outfile = NA, advertise = FALSE)
+  msg <- capture_messages(
+    out <- reprex(x, outfile = NA, advertise = FALSE)
+  )
   expect_match(out, "bbb", all = FALSE)
+  expect_messages_to_include(
+    msg,
+    c("Local `[.]Rprofile` detected", "bbb")
+  )
 
-  out <- reprex(input = aaa_foo, outfile = NA, advertise = FALSE)
+  msg <- capture_messages(
+    out <- reprex(input = aaa_foo, outfile = NA, advertise = FALSE)
+  )
   expect_match(out, "aaa", all = FALSE)
+  expect_messages_to_include(
+    msg,
+    c("Local `[.]Rprofile` detected", "aaa")
+  )
 })
 
 test_that("local .Rprofile reporting responds to venue", {
@@ -19,9 +33,10 @@ test_that("local .Rprofile reporting responds to venue", {
   expect_snapshot(rprofile_alert("r"))
 })
 
-test_that("local .Rprofile is reported", {
-  local_temp_wd()
-  cat("x <- 'aaa'\n", file = ".Rprofile")
-  out <- reprex(x, outfile = NA, advertise = FALSE)
-  expect_match(out, "Local `.Rprofile` detected", fixed = TRUE, all = FALSE)
+test_that("local .Rprofile not reported when it's not there", {
+  local_reprex_loud()
+  msg <- capture_messages(
+    reprex(1 + 1, advertise = FALSE)
+  )
+  expect_false(any(grepl(".Rprofile", msg, fixed = TRUE)))
 })


### PR DESCRIPTION
Closes #340
Closes #284

This ended up playing out in 3 specific ways:

* Make sure that `callr:r()` sees the reprex working directory as working directory, so that a project-specific `.Rprofile` callr loads is guaranteed to be same as the `.Rprofile` in working directory during reprex execution. I would regard `reprex()`'s behaviour w.r.t. this ever since callr's default changed to be ... undefined and/or wrong and/or surprising. With this behaviour, `reprex()`'s behaviour makes sense, by design.
* The usage of a local `.Rprofile` will now be indicated in the rendered reprex. I'm not 100% certain we should do this. In principle, it feels right, but there will be contexts where this may be annoying (e.g. `reprex_rtf()` for slides). Then people will want to be able to turn it on/off. Is the hassle worth it?
* The usage of a local `.Rprofile` now generates a user-facing alert. I'm almost 100% certain this is a good idea and won't face much resistance. Here's what that message looks like:
```
> reprex(x, outfile = NA, advertise = FALSE)
✓ Preparing reprex as `.R` file:
  reprex1214e62c2bd6c_reprex.R
! Local `.Rprofile` detected in reprex directory:
  /private/var/folders/.../reprextests-bbb-1214e74d0bd1d/.Rprofile
ℹ Rendering reprex...
✓ Writing reprex file:
  /private/var/folders/.../reprextests-bbb-1214e74d0bd1d/reprex1214e62c2bd6c_reprex.md
✓ Rendered reprex is on the clipboard.
```