### PR TITLE
BBcode venue

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(reprex)
 export(reprex_addin)
+export(reprex_bb)
 export(reprex_clean)
 export(reprex_document)
 export(reprex_html)

--- a/R/prex.R
+++ b/R/prex.R
@@ -31,7 +31,7 @@
 #' prex(getwd())    # current working directory
 prex <- function(x = NULL,
                  input = NULL,
-                 venue = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+                 venue = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
 
                  render = TRUE,
 
@@ -64,6 +64,7 @@ prex_html  <- function(...) prex(..., venue = "html")
 prex_r     <- function(...) prex(..., venue = "r")
 prex_rtf   <- function(...) prex(..., venue = "rtf")
 prex_slack <- function(...) prex(..., venue = "slack")
+prex_bb    <- function(...) prex(..., venue = "bb")
 
 # these should exist for completeness, but I predict they'd never get used and
 # they just clutter the auto-complete landscape

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -241,7 +241,7 @@
 #' @export
 reprex <- function(x = NULL,
                    input = NULL, wd = NULL,
-                   venue = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+                   venue = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
 
                    render = TRUE,
 

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -32,7 +32,7 @@
 #' @export
 #' @examples
 #' reprex_document()
-reprex_document <- function(venue = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+reprex_document <- function(venue = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
 
                             advertise       = NULL,
                             session_info    = opt(FALSE),

--- a/R/reprex_impl.R
+++ b/R/reprex_impl.R
@@ -1,7 +1,7 @@
 reprex_impl <- function(x_expr = NULL,
                         input  = NULL,
                         wd     = NULL,
-                        venue  = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+                        venue  = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
 
                         render = TRUE,
                         new_session = TRUE,
@@ -89,7 +89,7 @@ reprex_impl <- function(x_expr = NULL,
   }
 
   reprex_info("Rendering reprex...")
-  reprex_file <-reprex_render_impl(
+  reprex_file <- reprex_render_impl(
     r_file, new_session = new_session, html_preview = html_preview
   )
 
@@ -110,7 +110,8 @@ advertise_default <- function(venue) {
     so    = TRUE,
     r     = FALSE,
     rtf   = FALSE,
-    slack = FALSE
+    slack = FALSE,
+    bb    = FALSE
   )
   default[[venue]]
 }

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -322,9 +322,21 @@ pp_md_to_bb <- function(input) {
   output_lines <- read_lines(md_file(input))
   output_lines <- sub("^```[^`]+$", "[code=php]", output_lines, perl = TRUE)
   output_lines <- sub("^```$", "[/code]", output_lines, perl = TRUE)
-  output_lines <- bold_to_bb(output_lines)
-  output_lines <- italic_to_bb(output_lines)
   output_lines <- image_links_to_bb(output_lines)
+
+  code_index <- unlist(mapply(
+    FUN = seq,
+    grep("[code=php]", output_lines, fixed = TRUE),
+    grep("[/code]", output_lines, fixed = TRUE)
+  ))
+  img_index <- grep("[img]", output_lines, fixed = TRUE)
+
+  output_lines[-c(code_index, img_index)] <- italic_to_bb(
+    bold_to_bb(
+      output_lines[-c(code_index, img_index)]
+    )
+  )
+
   bbout_file <- bb_file(input)
   write_lines(output_lines, bbout_file)
   bbout_file

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -320,6 +320,7 @@ pp_slackify <- function(input) {
 pp_md_to_bb <- function(input) {
   bbout_file <- bb_file(input)
   output_lines <- read_lines(md_file(input))
+  # default to php to add syntaxic colours for all BBcode versions.
   output_lines[grep("^``` r$", output_lines)] <- "[code=php]"
   output_lines[grep("^```$", output_lines)] <- "[/code]"
   output_lines <- gsub("^!\\[\\]\\((.+)\\)$", "[img]\\1[/img]", output_lines)

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -154,6 +154,7 @@ reprex_render_impl <- function(input,
     rtf   = pp_highlight(pp_md_to_r(md_file, comment = comment)),
     slack = pp_slackify(md_file),
     html  = pp_html_render(md_file),
+    bb    = pp_md_to_bb(md_file),
     md_file
   )
 
@@ -312,6 +313,18 @@ pp_slackify <- function(input) {
   slack_file <- md_file_slack(input)
   write_lines(output_lines, slack_file)
   slack_file
+}
+
+# used when venue is "bb"
+# Hack to replace markdwon with bbcode for code chunks and images
+pp_md_to_bb <- function(input) {
+  bbout_file <- bb_file(input)
+  output_lines <- read_lines(md_file(input))
+  output_lines[grep("^``` r$", output_lines)] <- "[code=php]"
+  output_lines[grep("^```$", output_lines)] <- "[/code]"
+  output_lines <- gsub("^!\\[\\]\\((.+)\\)$", "[img]\\1[/img]", output_lines)
+  write_lines(output_lines, bbout_file)
+  bbout_file
 }
 
 # remove "info strings" from opening code fences, e.g. ```r

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -317,15 +317,26 @@ pp_slackify <- function(input) {
 
 # used when venue is "bb"
 # Hack to replace markdwon with bbcode for code chunks and images
+# "code=php" to add default syntaxic colours for all BBcode versions.
 pp_md_to_bb <- function(input) {
-  bbout_file <- bb_file(input)
   output_lines <- read_lines(md_file(input))
-  # default to php to add syntaxic colours for all BBcode versions.
-  output_lines[grep("^``` r$", output_lines)] <- "[code=php]"
-  output_lines[grep("^```$", output_lines)] <- "[/code]"
-  output_lines <- gsub("^!\\[\\]\\((.+)\\)$", "[img]\\1[/img]", output_lines)
+  output_lines <- sub("^```[^`]+$", "[code=php]", output_lines, perl = TRUE)
+  output_lines <- sub("^```$", "[/code]", output_lines, perl = TRUE)
+  output_lines <- bold_to_bb(output_lines)
+  output_lines <- italic_to_bb(output_lines)
+  output_lines <- image_links_to_bb(output_lines)
+  bbout_file <- bb_file(input)
   write_lines(output_lines, bbout_file)
   bbout_file
+}
+image_links_to_bb <- function(x) {
+  sub("(^!\\[\\]\\()(.+)(\\)$)", "[img]\\2[/img]", x, perl = TRUE)
+}
+bold_to_bb <- function(x) {
+  gsub("(__([^_]+)__)|(\\*\\*([^*]+)\\*\\*)", "[b]\\2\\4[/b]", x, perl = TRUE)
+}
+italic_to_bb <- function(x) {
+  gsub("(_([^_]+)_)|(\\*([^*]+)\\*)", "[i]\\2\\4[/i]", x, perl = TRUE)
 }
 
 # remove "info strings" from opening code fences, e.g. ```r

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -208,6 +208,10 @@ rmd_file <- function(path) {
   path_mutate(path, suffix = "reprex", ext = "Rmd")
 }
 
+bb_file <- function(path) {
+  path_mutate(path, suffix = "reprex", ext = "txt")
+}
+
 preview_file <- function(path) {
   path_mutate(path, suffix = "preview", ext = "html")
 }

--- a/R/venues.R
+++ b/R/venues.R
@@ -26,6 +26,10 @@ reprex_rtf <- function(...) reprex(..., venue = "rtf")
 #' @rdname reprex_venue
 reprex_slack <- function(...) reprex(..., venue = "slack")
 
+#' @export
+#' @rdname reprex_venue
+reprex_bb <- function(...) reprex(..., venue = "bb")
+
 # these should exist for completeness, but I predict they'd never get used and
 # they just clutter the auto-complete landscape
 # reprex_gh <- function(...) reprex(..., venue = "gh")

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -8,7 +8,7 @@ reprex(
   x = NULL,
   input = NULL,
   wd = NULL,
-  venue = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+  venue = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
   render = TRUE,
   advertise = NULL,
   session_info = opt(FALSE),

--- a/man/reprex_document.Rd
+++ b/man/reprex_document.Rd
@@ -5,7 +5,7 @@
 \title{reprex output format}
 \usage{
 reprex_document(
-  venue = c("gh", "r", "rtf", "html", "slack", "so", "ds"),
+  venue = c("gh", "r", "rtf", "html", "slack", "so", "ds", "bb"),
   advertise = NULL,
   session_info = opt(FALSE),
   style = opt(FALSE),

--- a/man/reprex_venue.Rd
+++ b/man/reprex_venue.Rd
@@ -6,6 +6,7 @@
 \alias{reprex_r}
 \alias{reprex_rtf}
 \alias{reprex_slack}
+\alias{reprex_bb}
 \title{Venue-specific shortcuts}
 \usage{
 reprex_html(...)
@@ -15,6 +16,8 @@ reprex_r(...)
 reprex_rtf(...)
 
 reprex_slack(...)
+
+reprex_bb(...)
 }
 \arguments{
 \item{...}{Passed along to \code{\link[=reprex]{reprex()}}.}

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -118,7 +118,8 @@ test_that("venue = 'bb' works", {
     "#' Hello world",
     "## comment",
     "1:5",
-    "#' Next is _italic_ or **bold** or even __*bold italic*__"
+    "#' Next is _italic_ or **bold** or even __*bold italic*__",
+    "code_with_underscores <- 1 * 2 * 3"
   )
   output <- c(
     "Hello world",
@@ -127,7 +128,10 @@ test_that("venue = 'bb' works", {
     "1:5",
     "#> [1] 1 2 3 4 5",
     "[/code]",
-    "Next is [i]italic[/i] or [b]bold[/b] or even [i][b]bold italic[/b][/i]"
+    "Next is [i]italic[/i] or [b]bold[/b] or even [i][b]bold italic[/b][/i]",
+    "[code=php]",
+    "code_with_underscores <- 1 * 2 * 3",
+    "[/code]"
   )
   ret <- reprex(input = input, venue = "bb")
   ret <- ret[nzchar(ret)]

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -117,7 +117,8 @@ test_that("venue = 'bb' works", {
   input <- c(
     "#' Hello world",
     "## comment",
-    "1:5"
+    "1:5",
+    "#' Next is _italic_ or **bold** or even __*bold italic*__"
   )
   output <- c(
     "Hello world",
@@ -125,7 +126,8 @@ test_that("venue = 'bb' works", {
     "## comment",
     "1:5",
     "#> [1] 1 2 3 4 5",
-    "[/code]"
+    "[/code]",
+    "Next is [i]italic[/i] or [i][b]bold italic[/b][/i]"
   )
   ret <- reprex(input = input, venue = "bb")
   ret <- ret[nzchar(ret)]

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -127,7 +127,7 @@ test_that("venue = 'bb' works", {
     "1:5",
     "#> [1] 1 2 3 4 5",
     "[/code]",
-    "Next is [i]italic[/i] or [i][b]bold italic[/b][/i]"
+    "Next is [i]italic[/i] or [b]bold[/b] or even [i][b]bold italic[/b][/i]"
   )
   ret <- reprex(input = input, venue = "bb")
   ret <- ret[nzchar(ret)]

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -121,7 +121,7 @@ test_that("venue = 'bb' works", {
   )
   output <- c(
     "Hello world",
-    "[code]",
+    "[code=php]",
     "## comment",
     "1:5",
     "#> [1] 1 2 3 4 5",

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -111,3 +111,23 @@ test_that("venue = 'slack' works", {
   ret <- ret[nzchar(ret)]
   expect_identical(ret, output)
 })
+
+test_that("venue = 'bb' works", {
+  skip_on_cran()
+  input <- c(
+    "#' Hello world",
+    "## comment",
+    "1:5"
+  )
+  output <- c(
+    "Hello world",
+    "[code]",
+    "## comment",
+    "1:5",
+    "#> [1] 1 2 3 4 5",
+    "[/code]"
+  )
+  ret <- reprex(input = input, venue = "bb")
+  ret <- ret[nzchar(ret)]
+  expect_identical(ret, output)
+})


### PR DESCRIPTION
As discussed in #350, here is the PR to add BBcode support (mostly for myself, I guess)
``` r
(reprex(c("#' Hello world", "## comment", "1:5"), venue = "bb"))
#> i Rendering reprex...
#> v Reprex output is on the clipboard.
#> [1] "[code=php]"                                          
#> [2] "c(\"#' Hello world\", \"## comment\", \"1:5\")"      
#> [3] "#> [1] \"#' Hello world\" \"## comment\"     \"1:5\""
#> [4] "[/code]"                                             
```

Currently, the BBcode output will look like this:
```
Hello world
[code=php]
## comment
1:5
#> [1] 1 2 3 4 5
[/code]
```
![image](https://user-images.githubusercontent.com/8896044/111483873-820f7680-8735-11eb-9798-bbc4a373dc44.png)

This PR only translates markdown R code chunk and markdown image tags to BBcode.

Edit: I'll add other common tags such as bold/italics.