### PR TITLE
deactivate extension about yaml metadata block for pandoc 2.13+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex (development version)
 
+`reprex_document()` has been adjusted for compatibility with changes introduced in Pandoc 2.13 around YAML headers (#375, #383 @cderv).
+
 `reprex_rtf()` (and the unexported `prex_rtf()`) work again.
 One of the filepaths involved in the highlight call was borked, but now it's not (#379).
 

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -116,7 +116,7 @@ reprex_document <- function(venue = c("gh", "r", "rtf", "html", "slack", "so", "
       opts_chunk = opts_chunk
     ),
     pandoc = rmarkdown::pandoc_options(
-      to = "gfm",
+      to = paste0("gfm", if (rmarkdown::pandoc_available("2.13")) "-yaml_metadata_block"),
       from = rmarkdown::from_rmarkdown(implicit_figures = FALSE),
       ext = ".md",
       args = pandoc_args

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -116,6 +116,7 @@ reprex_document <- function(venue = c("gh", "r", "rtf", "html", "slack", "so", "
       opts_chunk = opts_chunk
     ),
     pandoc = rmarkdown::pandoc_options(
+      # https://github.com/tidyverse/reprex/issues/375
       to = paste0("gfm", if (rmarkdown::pandoc_available("2.13")) "-yaml_metadata_block"),
       from = rmarkdown::from_rmarkdown(implicit_figures = FALSE),
       ext = ".md",


### PR DESCRIPTION
This fixes #375 on reprex side fro now

As explained in https://github.com/tidyverse/reprex/issues/375#issuecomment-828685324, we need to make a fix for Pandoc's change in **rmarkdown** but I am not sure reprex would benefit from it directly because of the way the `reprex_document()` format is built. By not using the `variant=` argument in `md_document()`, any variant specific logic for `gfm` inside `rmarkdown::md_document()` would not be applied. 

For a quick fix on **reprex** side, I have just added a switch to get Pandoc's extension deactivated for version 2.13 and above. This extension `yaml_metadata_block` has been activated by default in Pandoc now. This change in reprex does not require a new rmarkdown version.

I did not add tests for now. I wanted to wait for your guidance about how you would like it to be in your test organization. And also because tests in reprex that runs Pandoc are currently already failing with recent Pandoc versions. However, you don't test several Pandoc versions for now in GHA, only 2.7.3 (the default for `r-lib/actions/setup-pandoc`). 

Happy to discuss it further and work on another way to fix it (with a fix in rmarkdown and a change in reprex)



