### PR TITLE
Support rgl output in snippets.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     fortunes,
     miniUI,
     mockr,
+    rgl,
     rprojroot,
     sessioninfo,
     shiny,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The RStudio addin no longer displays a warning about condition length when
 selecting 'current file' as the reprex source (#391, @bisaloo).
+* If `rgl` code is run in the snippet, snapshots of the output
+will now be included.
 
 # reprex 2.0.1
 

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -110,6 +110,9 @@ reprex_document <- function(venue = c("gh", "r", "rtf", "html", "slack", "so", "
     write_lines(input_lines, knit_input)
   }
 
+  setHook(packageEvent("rgl", "onLoad"),
+          function(...) rgl::setupKnitr(autoprint = TRUE))
+
   format <- rmarkdown::output_format(
     knitr = rmarkdown::knitr_options(
       opts_knit = opts_knit,


### PR DESCRIPTION
This gets `knitr` to include snapshots of `rgl` output if rgl is loaded within the snippet. 

It should have almost no side effects if `rgl` is not used.

To disable snapshot inclusion in a code snippet, you can run

    rgl::setupKnitr(autoprint = FALSE)

or, before running any other code that would load `rgl`, 

    setHook(packageEvent("rgl", "onLoad"), NULL, "replace")
       
This fixes issue #404 .
