### PR TITLE
input file requires quoting to pass to `highlight`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex (development version)
 
+* Using `venue = "rtf"` is now possible on Windows when spaces are somewhere in file paths (e.g in Windows' username) (#409, @pieterjanvc).
+
 * The RStudio addin no longer displays a warning about condition length when
 selecting 'current file' as the reprex source (#391, @bisaloo).
 

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -2,7 +2,7 @@ reprex_highlight <- function(rout_file, reprex_file, arg_string = NULL) {
   arg_string <- arg_string %||% highlight_args()
   cmd <- paste0(
     "highlight ",
-    " -i ", rout_file,
+    " -i ", shQuote(rout_file),
     " --out-format=rtf --no-trailing-nl --encoding=UTF-8",
     arg_string,
     " -o ", reprex_file


### PR DESCRIPTION
To fix #409 

`shQuote()` would be the way to go in order to quote the input file path pass to `highlight()`. On Windows, it will use `type = "cmd"` to insert the correct quotes (double quote), on Unix (`type = "sh"`) it will be use single quotes.
I did a quick test on Windows and a path with space is now working. 

I believe it is also a good idea to use `shQuote()` for `sh` shell but if you prefer to be Windows only we could make it so. 



