### PR TITLE
Hypothetical patch release to fix HTML5 problems

### DIFF
--- a/.github/workflows/R-CMD-check-HTML5.yaml
+++ b/.github/workflows/R-CMD-check-HTML5.yaml
@@ -1,0 +1,42 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check-HTML5
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_RD_VALIDATE_RD2HTML_: TRUE
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install pdflatex
+        run: sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: Install tidy
+        run: sudo apt install tidy
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'devel'
+          http-user-agent: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: '"--as-cran"'
+          build_args: 'character()'
+          error-on: '"note"'

--- a/.github/workflows/R-CMD-check-HTML5.yaml
+++ b/.github/workflows/R-CMD-check-HTML5.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [v2.0.2-experiment,main, master]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check-HTML5.yaml
+++ b/.github/workflows/R-CMD-check-HTML5.yaml
@@ -36,6 +36,8 @@ jobs:
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        env:
+          NOT_CRAN: false
         with:
           args: '"--as-cran"'
           build_args: 'character()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reprex
 Title: Prepare Reproducible Example Code via the Clipboard
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: 
     c(person(given = "Jennifer",
              family = "Bryan",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,5 +67,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 SystemRequirements: pandoc (>= 2.0) - http://pandoc.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# reprex 2.0.2
+
 # reprex 2.0.1
 
 `reprex_document()` has been adjusted for compatibility with changes introduced in Pandoc 2.13 around YAML headers (#375, #383 @cderv).

--- a/man/reprex-package.Rd
+++ b/man/reprex-package.Rd
@@ -6,17 +6,9 @@
 \alias{_PACKAGE}
 \title{reprex: Prepare Reproducible Example Code via the Clipboard}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Convenience wrapper that uses the 'rmarkdown'
-    package to render small snippets of code to target formats that
-    include both code and output.  The goal is to encourage the sharing of
-    small, reproducible, and runnable examples on code-oriented websites,
-    such as <https://stackoverflow.com> and <https://github.com>, or in
-    email. The user's clipboard is the default source of input code and
-    the default target for rendered output. 'reprex' also extracts clean,
-    runnable R code from various common formats, such as copy/paste from
-    an R session.
+Convenience wrapper that uses the 'rmarkdown' package to render small snippets of code to target formats that include both code and output. The goal is to encourage the sharing of small, reproducible, and runnable examples on code-oriented websites, such as \url{https://stackoverflow.com} and \url{https://github.com}, or in email. The user's clipboard is the default source of input code and the default target for rendered output. 'reprex' also extracts clean, runnable R code from various common formats, such as copy/paste from an R session.
 }
 \seealso{
 Useful links:

--- a/man/reprex_options.Rd
+++ b/man/reprex_options.Rd
@@ -42,7 +42,9 @@ in the article
 
 Here's code you could put in \code{.Rprofile} to set reprex options. It would be
 rare to want non-default behaviour for all of these! We only do so here for
-the sake of exposition:\preformatted{options(
+the sake of exposition:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{options(
   reprex.advertise       = FALSE,
   reprex.session_info    = TRUE,
   reprex.style           = TRUE,
@@ -56,23 +58,29 @@ the sake of exposition:\preformatted{options(
   reprex.highlight.font_size = 35,
   reprex.highlight.other     = "--line-numbers"
 )
-}
+}\if{html}{\out{</div>}}
 
 The function \code{usethis::edit_r_profile()} is handy for creating and/or opening
 your \code{.Rprofile}.
 }
 \section{Explaining the \code{opt()} helper}{
 
-Arguments that appear like so in \code{\link[=reprex]{reprex()}}:\preformatted{reprex(..., arg = opt(DEFAULT), ...)
-}
+Arguments that appear like so in \code{\link[=reprex]{reprex()}}:
 
-get their value according to this logic:\preformatted{user-specified value or, if not given,
+\if{html}{\out{<div class="sourceCode">}}\preformatted{reprex(..., arg = opt(DEFAULT), ...)
+}\if{html}{\out{</div>}}
+
+get their value according to this logic:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{user-specified value or, if not given,
   getOption("reprex.arg") or, if does not exist,
     DEFAULT
-}
+}\if{html}{\out{</div>}}
 
-It's shorthand for:\preformatted{f(..., arg = getOption("reprex.arg", DEFAULT), ...)
-}
+It's shorthand for:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{f(..., arg = getOption("reprex.arg", DEFAULT), ...)
+}\if{html}{\out{</div>}}
 
 This is not an exported function and should not be called directly.
 }

--- a/man/reprex_render.Rd
+++ b/man/reprex_render.Rd
@@ -25,7 +25,9 @@ of the output file.
 }
 \description{
 This is a wrapper around \code{\link[rmarkdown:render]{rmarkdown::render()}} that enforces the "reprex"
-mentality. Here's a simplified version of what happens:\preformatted{callr::r(
+mentality. Here's a simplified version of what happens:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{callr::r(
   function(input) \{
     rmarkdown::render(input, envir = globalenv(), encoding = "UTF-8")
   \},
@@ -33,7 +35,7 @@ mentality. Here's a simplified version of what happens:\preformatted{callr::r(
   spinner = is_interactive(),
   stdout = std_file, stderr = std_file
 )
-}
+}\if{html}{\out{</div>}}
 
 Key features to note
 \itemize{

--- a/man/un-reprex.Rd
+++ b/man/un-reprex.Rd
@@ -91,20 +91,20 @@ wild-caught reprex.
 }
 \section{Functions}{
 \itemize{
-\item \code{reprex_invert}: Attempts to reverse the effect of \code{\link[=reprex]{reprex()}}. When
+\item \code{reprex_invert()}: Attempts to reverse the effect of \code{\link[=reprex]{reprex()}}. When
 \code{venue = "r"}, this just calls \code{reprex_clean()}.
 
-\item \code{reprex_clean}: Assumes R code is top-level, possibly interleaved with
+\item \code{reprex_clean()}: Assumes R code is top-level, possibly interleaved with
 commented output, e.g., a displayed reprex copied from GitHub or the direct
 output of \code{reprex(..., venue = "R")}. This function removes commented
 output.
 
-\item \code{reprex_rescue}: Assumes R code lines start with a prompt and that
+\item \code{reprex_rescue()}: Assumes R code lines start with a prompt and that
 printed output is top-level, e.g., what you'd get from copy/paste from the
 R Console. Removes lines of output and strips prompts from lines holding R
 commands.
-}}
 
+}}
 \examples{
 \dontrun{
 # a roundtrip: R code --> rendered reprex, as gfm --> R code


### PR DESCRIPTION
Experiment / demo of how to branch off a previous release to make a small patch release. The important part re: verifying that the specific NOTE has been fixed is shown by the "red to green" transition below in the GHA results.

(However, this is not how I did the HTML5-fixing release in reprex; I made a normal patch release from `main`. Closing this, unmerged.)

