### PR TITLE
Adjust utils-io test for lifecycle 1.0.3+

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     fs,
     glue,
     knitr (>= 1.23),
-    lifecycle,
+    lifecycle (>= 1.0.3),
     rlang (>= 1.0.0),
     rmarkdown,
     rstudioapi,

--- a/tests/testthat/_snaps/utils-io.md
+++ b/tests/testthat/_snaps/utils-io.md
@@ -1,26 +1,26 @@
 # retrofit_files() works
 
     The `outfile` argument of `reprex()` is deprecated as of reprex 2.0.0.
-    Please use the `wd` argument instead.
+    i Please use the `wd` argument instead.
 
 ---
 
     The `outfile` argument of `reprex()` is deprecated as of reprex 2.0.0.
-    Use `reprex(wd = ".")` instead of `reprex(outfile = NA)`.
+    i Use `reprex(wd = ".")` instead of `reprex(outfile = NA)`.
 
 ---
 
     The `outfile` argument of `reprex()` is deprecated as of reprex 2.0.0.
-    * To control output filename, provide a filepath to `input`.
-    * Only taking working directory from `outfile`.
+    i To control output filename, provide a filepath to `input`.
+    i Only taking working directory from `outfile`.
 
 ---
 
     The `outfile` argument of `reprex()` is deprecated as of reprex 2.0.0.
-    Working directory will be derived from `input`.
+    i Working directory will be derived from `input`.
 
 ---
 
     The `outfile` argument of `reprex()` is deprecated as of reprex 2.0.0.
-    Working directory and output filename will be determined from `input`.
+    i Working directory and output filename will be determined from `input`.
 


### PR DESCRIPTION
With lifecycle 1.0.3, the behavior of deprecate_warn() changed slightly. Specifically, when details is set, but not via a named vector, it now uses an info bullet by default. See: https://github.com/r-lib/lifecycle/commit/54ef5416e303d488a82e978adf2c39f5d83e4836

This change adjusts the utils-io.md expected strings to reflect the new result (and makes lifecycle >= 1.0.3 a requirement).

(the other way to fix this would be to use set_names() in utils-io.R, but that seemed more intrusive.)

With this change, the tests pass again with lifecycle 1.0.3+.