### PR TITLE
Various test lints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     shiny,
     spelling,
     styler (>= 1.2.0),
-    testthat (>= 3.0.2)
+    testthat (>= 3.2.0)
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     shiny,
     spelling,
     styler (>= 1.2.0),
-    testthat (>= 3.2.0)
+    testthat (>= 3.2.1)
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/tests/testthat/_snaps/reprex.md
+++ b/tests/testthat/_snaps/reprex.md
@@ -7,3 +7,12 @@
     [5] "#> 3     1    1     1    1  3      0   expr    FALSE"     
     [6] "```"                                                      
 
+# reprex() errors for an R crash, by default
+
+    Code
+      code <- "utils::getFromNamespace(\"crash\", \"callr\")()\n"
+      reprex(input = code)
+    Condition
+      Error in `reprex_render()`:
+      ! This reprex appears to crash R. Call `reprex()` again with `std_out_err = TRUE` to get more info.
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -18,10 +18,6 @@ if (getRversion() >= "4.0.0" && identical(Sys.getenv("CI"), "true")) {
   )
 }
 
-expect_error_free <- function(...) {
-  expect_error(..., regexp = NA)
-}
-
 expect_messages_to_include <- function(haystack, needles) {
   lapply(
     needles,

--- a/tests/testthat/test-knitr-options.R
+++ b/tests/testthat/test-knitr-options.R
@@ -8,7 +8,7 @@ test_that("reprex() suppresses tidyverse startup message by default", {
   skip_on_cran()
   skip_if_not_installed("tidyverse", minimum_version = "1.2.1")
   ret <- reprex(input = sprintf("library(%s)\n", "tidyverse"))
-  expect_false(any(grepl("Attaching", ret)))
+  expect_no_match(ret, "Attaching")
 })
 
 test_that("`tidyverse_quiet` works", {
@@ -19,7 +19,7 @@ test_that("`tidyverse_quiet` works", {
     input = "library(tidyverse)\n",
     tidyverse_quiet = TRUE
   )
-  expect_false(any(grepl("Attaching", ret)))
+  expect_no_match(ret, "Attaching")
 
   ret <- reprex(
     input = "library(tidyverse)\n",
@@ -36,7 +36,7 @@ test_that("`tidyverse_quiet` works for tidymodels", {
     input = "library(tidymodels)\n",
     tidyverse_quiet = TRUE
   )
-  expect_false(any(grepl("Attaching", ret)))
+  expect_no_match(ret, "Attaching")
 
   ret <- reprex(
     input = "library(tidymodels)\n",

--- a/tests/testthat/test-outfiles.R
+++ b/tests/testthat/test-outfiles.R
@@ -57,10 +57,10 @@ test_that("expected outfiles are written and messaged, venue = 'html'", {
 
   outfiles <- dir_ls()
   # punting on the issue of the `utf8.md` file and folder of files
-  expect_true(all(
-    c("_reprex.R", "_reprex.md", "_reprex.html") %in%
-      gsub("[a-z-]+(_reprex.+)", "\\1", outfiles)
-  ))
+  expect_contains(
+    gsub("[a-z-]+(_reprex.+)", "\\1", outfiles),
+    c("_reprex.R", "_reprex.md", "_reprex.html")
+  )
   html_file <- grep("_reprex[.]html", outfiles, value = TRUE)
   expect_equal(ret, read_lines(html_file))
 

--- a/tests/testthat/test-reprex-options.R
+++ b/tests/testthat/test-reprex-options.R
@@ -22,7 +22,7 @@ test_that("`advertise` can be set via option", {
     list(reprex.advertise = FALSE),
     out <- reprex(1, render = FALSE)
   )
-  expect_false(any(grepl("#+ reprex-ad", out, fixed = TRUE)))
+  expect_no_match(out, "#+ reprex-ad", fixed = TRUE)
 })
 
 test_that("`comment` can be set via option", {

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -31,8 +31,7 @@ test_that("rmarkdown::render() context is trimmed from rlang backtrace", {
     "rlang::last_trace()"
   )
   ret <- reprex(input = input, advertise = FALSE)
-  expect_false(any(grepl("tryCatch", ret)))
-  expect_false(any(grepl("rmarkdown::render", ret)))
+  expect_no_match(ret, regexp = "tryCatch|rmarkdown::render")
 })
 
 test_that("rlang::last_error() and last_trace() work", {
@@ -49,28 +48,28 @@ test_that("rlang::last_error() and last_trace() work", {
   )
   ret <- reprex(input = input, advertise = FALSE)
   m <- match("rlang::last_error()", ret)
-  expect_false(grepl("Error", ret[m + 1]))
+  expect_no_match(ret[m + 1], "Error")
   m <- match("rlang::last_trace()", ret)
-  expect_false(grepl("Error", ret[m + 1]))
+  expect_no_match(ret[m + 1], "Error")
 })
 
 test_that("reprex() works even if user uses fancy quotes", {
   skip_on_cran()
   withr::local_options(list(useFancyQuotes = TRUE))
   # use non-default venue to force some quoted yaml to be written
-  expect_error_free(reprex(1, venue = "R"))
+  expect_no_error(reprex(1, venue = "R"))
 })
 
 test_that("reprex() errors for an R crash, by default", {
-  # TODO: consider switching to expect_snapshot() after switch to 3e
+  # TODO: consider switching to expect_snapshot()
   code <- 'utils::getFromNamespace("crash", "callr")()\n'
   expect_error(reprex(input = code), "crash")
 })
 
 test_that("reprex() copes with an R crash, when `std_out_err = TRUE`", {
-  # TODO: consider switching to expect_snapshot() after switch to 3e
+  # TODO: consider switching to expect_snapshot()
   code <- 'utils::getFromNamespace("crash", "callr")()\n'
-  expect_error_free(
+  expect_no_error(
     out <- reprex(input = code, std_out_err = TRUE)
   )
   skip_on_os("windows")

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -61,13 +61,13 @@ test_that("reprex() works even if user uses fancy quotes", {
 })
 
 test_that("reprex() errors for an R crash, by default", {
-  # TODO: consider switching to expect_snapshot()
-  code <- 'utils::getFromNamespace("crash", "callr")()\n'
-  expect_error(reprex(input = code), "crash")
+  expect_snapshot(error = TRUE, {
+    code <- 'utils::getFromNamespace("crash", "callr")()\n'
+    reprex(input = code)
+  })
 })
 
 test_that("reprex() copes with an R crash, when `std_out_err = TRUE`", {
-  # TODO: consider switching to expect_snapshot()
   code <- 'utils::getFromNamespace("crash", "callr")()\n'
   expect_no_error(
     out <- reprex(input = code, std_out_err = TRUE)

--- a/tests/testthat/test-rprofile.R
+++ b/tests/testthat/test-rprofile.R
@@ -37,5 +37,5 @@ test_that("local .Rprofile not reported when it's not there", {
   msg <- capture_messages(
     reprex(1 + 1, advertise = FALSE)
   )
-  expect_false(any(grepl(".Rprofile", msg, fixed = TRUE)))
+  expect_no_match(msg, ".Rprofile", fixed = TRUE)
 })

--- a/tests/testthat/test-session-info.R
+++ b/tests/testthat/test-session-info.R
@@ -7,7 +7,7 @@ test_that("session info is omitted / included", {
   }
   input <- c("(y <- 1:4)", "mean(y)")
   ret <- reprex(input = input)
-  expect_false(any(grepl(regex, ret)))
+  expect_no_match(ret, regex)
   ret <- reprex(input = input, session_info = TRUE)
   expect_match(ret, regex, all = FALSE)
 })

--- a/tests/testthat/test-stdout-stderr.R
+++ b/tests/testthat/test-stdout-stderr.R
@@ -15,5 +15,5 @@ test_that("stdout placeholder appears if nothing is captured", {
 test_that("stdout placeholder is absent if explicitly excluded", {
   skip_on_cran()
   out <- reprex(1:4, std_out_err = FALSE)
-  expect_false(any(grepl("standard output and standard error", out)))
+  expect_no_match(out, "standard output and standard error")
 })

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -8,16 +8,16 @@ test_that("UTF-8 encoding, string input", {
   )
   out_utf8 <- reprex(input = in_utf8)
 
-  expect_true(all(Encoding(out_utf8) %in% c("unknown", "UTF-8")))
+  expect_in(Encoding(out_utf8), c("unknown", "UTF-8"))
 
-  i_in <-  grep("^x <-", in_utf8)
-  i_out <- grep("^x <-", out_utf8)
-  expect_identical(charToRaw(in_utf8[i_in]), charToRaw(out_utf8[i_out]))
+  line_in <-  grep("^x <-", in_utf8, value = TRUE)
+  line_out <- grep("^x <-", out_utf8, value = TRUE)
+  expect_identical(charToRaw(line_in), charToRaw(line_out))
 
-  i_out <- grep("^#> \\[1\\]", out_utf8)
-  expect_match(out_utf8[i_out], "[\u00C0]")
-  expect_match(out_utf8[i_out], "[\u00CB]")
-  expect_match(out_utf8[i_out], "[\u00D0]")
+  line_out <- grep("^#> \\[1\\]", out_utf8, value = TRUE)
+  expect_match(line_out, "[\u00C0]")
+  expect_match(line_out, "[\u00CB]")
+  expect_match(line_out, "[\u00D0]")
 
   in_latin1 <- iconv(in_utf8, from = "UTF-8", to = "latin1")
   out_latin1 <- reprex(input = in_latin1)

--- a/tests/testthat/test-venues.R
+++ b/tests/testthat/test-venues.R
@@ -67,8 +67,9 @@ test_that("local image link is not interrupted by hard line break for 'gh'", {
     "plot(1:3)"
   )
   out <- reprex(input = input, venue = "gh")
-  i <- grep("incredibly-long", out)
-  expect_true(grepl("[)]", out[i]))
+  line <- grep("incredibly-long", out, value = TRUE)
+  expect_length(line, 1)
+  expect_match(line, "[)]")
 })
 
 test_that("venue = 'html' works", {


### PR DESCRIPTION
Use `expect_no_error()` + other goodies from testthat 3.2.0 to make the tests a bit more clear.