### PR TITLE
Freshen up the tests around crashing

### DIFF
--- a/tests/testthat/_snaps/reprex.md
+++ b/tests/testthat/_snaps/reprex.md
@@ -10,9 +10,26 @@
 # reprex() errors for an R crash, by default
 
     Code
-      code <- "utils::getFromNamespace(\"crash\", \"callr\")()\n"
+      code <- "rlang::node_car(0)\n"
       reprex(input = code)
     Condition
       Error in `reprex_render()`:
       ! This reprex appears to crash R. Call `reprex()` again with `std_out_err = TRUE` to get more info.
+
+# reprex() copes with an R crash, when `std_out_err = TRUE`
+
+    Code
+      out
+    Output
+      [1] "This reprex appears to crash R."
+      [2] "See standard output and standard error for more details."
+      [3] ""
+      [4] "#### Standard output and error"
+      [5] ""
+      [6] "``` sh"
+      [7] ""
+      [8] " *** caught segfault ***"
+      [9] "address ADDRESS, cause 'CAUSE'"
+      [10] ""
+      [11] "Traceback:"
 


### PR DESCRIPTION
Motivated by:

> Dear maintainer,
>
> Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_reprex.html>.
>
> Please correct before 2024-07-07 to safely retain your package on CRAN.

This refers to the fact that, at the time of writing, `callr:::crash()` does not crash on R devel, but instead throws an error. So reprex's tests around its behaviour when R crashes are failing on CRAN's checks on R-devel.

I'm updating to use a different way of crashing R (but @gaborcsardi says he'll probably update callr's R-crashing code) and also adding `skip_on_cran()`, as it seems a bit fraught to test crashing R there.

```
══ Failed tests ════════════════════════════════════════════════════════════════
    ── Failure ('test-reprex.R:67:3'): reprex() errors for an R crash, by default ──
    `reprex(input = code)` did not throw the expected error.
    ── Failure ('test-reprex.R:78:3'): reprex() copes with an R crash, when `std_out_err = TRUE` ──
    `out` does not match "segfault".
    Actual values:
    * ``` r
    * utils::getFromNamespace\("crash", "callr"\)\(\)
    * #> Error in get\("attach"\)\(structure\(list\(\), class = "UserDefinedDatabase"\)\): R_ExternalPtrAddr: argument of type VECSXP is not an external pointer
    * ```
    * 
    * <sup>Created on 2024-07-02 with \[reprex v2\.1\.0\]\(https://reprex\.tidyverse\.org\)</sup>
    * 
    * <details style="margin-bottom:10px;">
    * 
    * <summary>
    * 
    * Standard output and standard error
    * </summary>
    * 
    * 
    * ``` sh
    * -- nothing to show --
    * ```
    * 
    * </details>
    Backtrace:
        ▆
     1. └─testthat::expect_match(out, "segfault", all = FALSE) at test-reprex.R:78:3
     2.   └─testthat:::expect_match_(...)
    ── Failure ('test-reprex.R:79:3'): reprex() copes with an R crash, when `std_out_err = TRUE` ──
    `out` does not match "Traceback".
    Actual values:
    * ``` r
    * utils::getFromNamespace\("crash", "callr"\)\(\)
    * #> Error in get\("attach"\)\(structure\(list\(\), class = "UserDefinedDatabase"\)\): R_ExternalPtrAddr: argument of type VECSXP is not an external pointer
    * ```
    * 
    * <sup>Created on 2024-07-02 with \[reprex v2\.1\.0\]\(https://reprex\.tidyverse\.org\)</sup>
    * 
    * <details style="margin-bottom:10px;">
    * 
    * <summary>
    * 
    * Standard output and standard error
    * </summary>
    * 
    * 
    * ``` sh
    * -- nothing to show --
    * ```
    * 
    * </details>
    Backtrace:
        ▆
     1. └─testthat::expect_match(out, "Traceback", all = FALSE) at test-reprex.R:79:3
     2.   └─testthat:::expect_match_(...)
    
    [ FAIL 3 | WARN 0 | SKIP 65 | PASS 60 ]
    Error: Test failures
    Execution halted
```
