### PR TITLE
Improve html preview

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -194,6 +194,7 @@ preview <- function(input) {
   )
   args <- c(
     "--standalone", "--embed-resources",
+    "--highlight-style", path(res_dir, glue("starry-nights-{mode}.theme")),
     "--css", path(res_dir, glue("github-{mode}.css")),
     "--metadata", "pagetitle=PREVIEW",
     "--quiet"

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -196,6 +196,7 @@ preview <- function(input) {
     "--standalone", "--embed-resources",
     "--highlight-style", path(res_dir, glue("starry-nights-{mode}.theme")),
     "--css", path(res_dir, glue("github-{mode}.css")),
+    "--syntax-definition", path(res_dir, "r.xml"),
     "--metadata", "pagetitle=PREVIEW",
     "--quiet"
   )

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -199,7 +199,6 @@ preview <- function(input) {
   )
   args <- c(
     "--standalone", "--self-contained",
-    "--highlight-style", "pygments",
     "--template", template,
     "--variable", css,
     "--metadata", "pagetitle=PREVIEW",

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -212,7 +212,7 @@ preview <- function(input) {
   preview_file <- preview_file(input)
   rmarkdown::pandoc_convert(
     input = input, to = "html", from = "gfm", output = preview_file,
-    options = args, verbose = TRUE
+    options = args, verbose = FALSE
   )
 
   # can be interesting re: detecting how we were called and what we should

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -182,25 +182,19 @@ reprex_render_impl <- function(input,
   invisible(reprex_file)
 }
 
-# heavily influenced by the post_processor() function of github_document()
+# influenced by the post_processor() function of github_document()
+# but with substantial reprex-specific updates in 2024-09
 preview <- function(input) {
-  css <- rmarkdown::pandoc_path_arg(
+  mode <- if (is_dark_mode()) "dark" else "light"
+  res_dir <- rmarkdown::pandoc_path_arg(
     path_package(
-      "rmarkdown",
-      "rmarkdown/templates/github_document/resources/github.css"
-    )
-  )
-  css <- glue("github-markdown-css:{css}")
-  template <- rmarkdown::pandoc_path_arg(
-    path_package(
-      "rmarkdown",
-      "rmarkdown/templates/github_document/resources/preview.html"
+      "reprex",
+      glue("rmarkdown/templates/reprex_document/resources")
     )
   )
   args <- c(
-    "--standalone", "--self-contained",
-    "--template", template,
-    "--variable", css,
+    "--standalone", "--embed-resources",
+    "--css", path(res_dir, glue("github-{mode}.css")),
     "--metadata", "pagetitle=PREVIEW",
     "--quiet"
   )
@@ -216,7 +210,7 @@ preview <- function(input) {
   preview_file <- preview_file(input)
   rmarkdown::pandoc_convert(
     input = input, to = "html", from = "gfm", output = preview_file,
-    options = args, verbose = FALSE
+    options = args, verbose = TRUE
   )
 
   # can be interesting re: detecting how we were called and what we should

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,3 +63,12 @@ newline <- function(x) paste0(x, "\n")
 is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
+
+is_dark_mode <- function() {
+  if (rstudioapi::isAvailable() && rstudioapi::hasFun("getThemeInfo")) {
+    theme_info <- rstudioapi::getThemeInfo()
+    theme_info$dark
+  } else {
+    FALSE
+  }
+}

--- a/data-raw/github_css.R
+++ b/data-raw/github_css.R
@@ -1,0 +1,20 @@
+# use the CSS found here:
+# https://github.com/sindresorhus/github-markdown-css
+# which aims to be:
+# "The minimal amount of CSS to replicate the GitHub Markdown style"
+
+library(usethis)
+
+use_directory("inst/rmarkdown/templates/reprex_document/resources")
+
+use_github_file(
+  repo_spec = "sindresorhus/github-markdown-css",
+  path = "github-markdown-dark.css",
+  save_as = "inst/rmarkdown/templates/reprex_document/resources/github-dark.css"
+)
+
+use_github_file(
+  repo_spec = "sindresorhus/github-markdown-css",
+  path = "github-markdown-light.css",
+  save_as = "inst/rmarkdown/templates/reprex_document/resources/github-light.css"
+)

--- a/data-raw/pandoc-syntax-highlighting.R
+++ b/data-raw/pandoc-syntax-highlighting.R
@@ -1,0 +1,195 @@
+# write Pandoc's default (pygments) highlight style to a JSON file
+# pandoc --print-highlight-style pygments > data-raw/pygments.theme
+# use this as a scaffold, but modify colors to match the Starry Night theme
+# that GitHub uses
+
+library(tidyverse)
+
+pyg <- jsonlite::fromJSON("data-raw/pygments.theme")
+pyg |> pluck("text-styles") |> names()
+
+# How does Pandoc do syntax highlighting?
+# https://pandoc.org/chunkedhtml-demo/13-syntax-highlighting.html
+# "The Haskell library skylighting is used for highlighting."
+
+# Pandoc/skylighting store themes using the
+# Syntax-Highlighting framework from KDE Frameworks
+
+# Learn the meaning of the styles (classes) supported by Pandoc here:
+# https://docs.kde.org/stable5/en/kate/katepart/highlight.html
+#   see "Available Default Styles"
+# https://docs.kde.org/stable5/en/kate/katepart/color-themes.html
+#   see "Default Text Styles"
+
+# this is me taking the styles Pandoc/skylighting expects,
+# noting what they are meant for conceptually,
+# and picking the starry-night color alias/variable that seems the best fit
+
+x <- str_glue('
+  Alert,"Text style for special words in comments, such as TODO, FIXME, XXXX and WARNING.",\\
+  comment,
+  Annotation,"Text style for annotations in comments or documentation commands, such as @param in Doxygen or JavaDoc.",\\
+  comment,
+  Attribute,"Text style for annotations or attributes of functions or objects, e.g. @override in Java, or __declspec(...) and __attribute__((...)) in C++.",\\
+  entity-tag,
+  BaseN,"(Base-N Integer): Text style for numbers with base other than 10.",\\
+  constant,
+  BuiltIn,"(Built-in): Text style for built-in language classes, functions and objects.",\\
+  entity,
+  Char,"(Character): Text style for single characters such as \'x\'.",\\
+  string,
+  Comment, "Text style for normal comments.",\\
+  comment,
+  CommentVar,"(Comment Variable): Text style that refers to variables names used in above commands in a comment, such as foobar in \'@param foobar\', in Doxygen or JavaDoc.",\\
+  comment,
+  Constant,"Text style for language constants and user defined constants, e.g. True, False, None in Python or nullptr in C/C++; or math constants like PI.",\\
+  constant,
+  ControlFlow,"(Control Flow): Text style for control flow keywords, such as if, then, else, return, switch, break, yield, continue, etc.",\\
+  keyword,
+  DataType,"(Data Type): Text style for built-in data types such as int, char, float, void, u64, etc.",\\
+  constant,
+  DecVal,"(Decimal/Value): Text style for decimal values.",\\
+  constant,
+  Documentation,"Text style for comments that reflect API documentation, such as /** doxygen comments */ or \"\"\"docstrings\"\"\".",\\
+  comment,
+  Error,"Text style indicating error highlighting and wrong syntax.",\\
+  invalid-illegal-text,invalid-illegal-bg
+  Extension,"Text style for well-known extensions, such as Qt™ classes, functions/macros in C++ and Python or boost.",\\
+  entity,
+  Float,"(Floating Point): Text style for floating point numbers.",\\
+  constant,
+  Function,"Text style for function definitions and function calls.",\\
+  entity,
+  Import,"(Imports, Modules, Includes): Text style for includes, imports, modules or LATEX packages.",\\
+  storage-modifier-import,
+  Information,"Text style for information, notes and tips, such as the keyword @note in Doxygen.",\\
+  comment,
+  Keyword,"Text style for built-in language keywords.",\\
+  keyword,
+  Operator,"Text style for operators, such as +, -, *, /, %, etc.",\\
+  keyword,
+  Others,"Text style for attributes that do not match any of the other default styles.",\\
+  ,
+  Preprocessor,"Text style for preprocessor statements or macro definitions.",\\
+  keyword,
+  SpecialChar,"(Special Character): Text style for escaped characters in strings, e.g. \"hello\\n\", and other characters with special meaning in strings, such as substitutions or regex operators.",\\
+  carriage-return-text,carriage-return-bg
+  SpecialString,"(Special String): Text style for special strings, such as regular expressions in ECMAScript, the LATEX math mode, SQL, etc.",\\
+  string-regexp,
+  String,"Text style for strings like \"hello world\".",\\
+  string,
+  Variable,"Text style for variables, if applicable. For instance, variables in PHP/Perl typically start with a $, so all identifiers following the pattern $foo are highlighted as variable.",\\
+  variable,
+  VerbatimString,"(Verbatim String): Text style for verbatim or raw strings like \'raw \backlash\' in Perl, CoffeeScript, and shells, as well as r\'\raw\' in Python, or such as HERE docs.",\\
+  string,
+  Warning,"Text style for warnings, such as the keyword @warning in Doxygen.",\\
+  comment,
+')
+
+dat <- read_csv(x, col_names = c("pyg_class", "pyg_note", "pl_text_style", "pl_background_style"))
+dat
+
+# get the starry-night css in order to excavate the colors
+use_github_file(
+  repo_spec = "wooorm/starry-night",
+  path = "style/dark.css",
+  save_as = "data-raw/starry-night-dark.css"
+)
+
+use_github_file(
+  repo_spec = "wooorm/starry-night",
+  path = "style/light.css",
+  save_as = "data-raw/starry-night-light.css"
+)
+
+raw_css_lines <- readLines("data-raw/starry-night-light.css")
+sn_light <- raw_css_lines |>
+  str_subset("  --color-prettylights-syntax-") |>
+  tibble() |>
+  set_names("raw") |>
+  mutate(comment = str_extract(raw, ".+:")) |>
+  mutate(color = str_extract(raw, "#[0-9a-fA-F]{6}")) |>
+  mutate(comment = str_remove(comment, "  --color-prettylights-syntax-")) |>
+  mutate(comment = str_remove(comment, ":$")) |>
+  select(comment, color)
+
+raw_css_lines <- readLines("data-raw/starry-night-dark.css")
+sn_dark <- raw_css_lines |>
+  str_subset("  --color-prettylights-syntax-") |>
+  tibble() |>
+  set_names("raw") |>
+  mutate(comment = str_extract(raw, ".+:")) |>
+  mutate(color = str_extract(raw, "#[0-9a-fA-F]{6}")) |>
+  mutate(comment = str_remove(comment, "  --color-prettylights-syntax-")) |>
+  mutate(comment = str_remove(comment, ":$")) |>
+  select(comment, color)
+
+dat
+sn_light
+sn_dark
+
+dat_light <- dat |>
+  rename(cls = pyg_class) |>
+  select(-pyg_note) |>
+  left_join(
+    sn_light,
+    by = join_by(pl_text_style == comment)
+  ) |>
+  rename(txt_col = color) |>
+  left_join(
+    sn_light,
+    by = join_by(pl_background_style == comment)
+  ) |>
+  rename(bg_col = color) |>
+  select(-starts_with("pl_"))
+dat_light
+
+dat_dark <- dat |>
+  rename(cls = pyg_class) |>
+  select(-pyg_note) |>
+  left_join(
+    sn_dark,
+    by = join_by(pl_text_style == comment)
+  ) |>
+  rename(txt_col = color) |>
+  left_join(
+    sn_dark,
+    by = join_by(pl_background_style == comment)
+  ) |>
+  rename(bg_col = color) |>
+  select(-starts_with("pl_"))
+dat_dark
+
+g <- function(cls, txt_col, bg_col) {
+  list(
+    `text-color` = txt_col,
+    `background-color` = bg_col,
+    bold = FALSE,
+    italic = FALSE,
+    underline = FALSE
+  )
+}
+
+theme_light <- theme_dark <- pyg
+theme_light[["text-styles"]] <- dat_light |>
+  pmap(g) |>
+  set_names(dat_light$cls)
+theme_dark[["text-styles"]] <- dat_dark |>
+  pmap(g) |>
+  set_names(dat_dark$cls)
+
+jsonlite::write_json(
+  theme_light,
+  "inst/rmarkdown/templates/reprex_document/resources/starry-nights-light.theme",
+  null = "null",
+  auto_unbox = TRUE,
+  pretty = TRUE
+)
+
+jsonlite::write_json(
+  theme_dark,
+  "inst/rmarkdown/templates/reprex_document/resources/starry-nights-dark.theme",
+  null = "null",
+  auto_unbox = TRUE,
+  pretty = TRUE
+)

--- a/data-raw/pygments.theme
+++ b/data-raw/pygments.theme
@@ -1,0 +1,211 @@
+{
+    "text-color": null,
+    "background-color": null,
+    "line-number-color": "#aaaaaa",
+    "line-number-background-color": null,
+    "text-styles": {
+        "Alert": {
+            "text-color": "#ff0000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Annotation": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Attribute": {
+            "text-color": "#7d9029",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "BaseN": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "BuiltIn": {
+            "text-color": "#008000",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Char": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Comment": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
+        },
+        "CommentVar": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Constant": {
+            "text-color": "#880000",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "ControlFlow": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "DataType": {
+            "text-color": "#902000",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "DecVal": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Documentation": {
+            "text-color": "#ba2121",
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
+        },
+        "Error": {
+            "text-color": "#ff0000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Extension": {
+            "text-color": null,
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Float": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Function": {
+            "text-color": "#06287e",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Import": {
+            "text-color": "#008000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Information": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Keyword": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Operator": {
+            "text-color": "#666666",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Other": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Preprocessor": {
+            "text-color": "#bc7a00",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "SpecialChar": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "SpecialString": {
+            "text-color": "#bb6688",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "String": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Variable": {
+            "text-color": "#19177c",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "VerbatimString": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Warning": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        }
+    }
+}

--- a/data-raw/r-syntax-definition.R
+++ b/data-raw/r-syntax-definition.R
@@ -1,0 +1,19 @@
+library(usethis)
+
+# the true source lives in KDE's GitLab instance, but I think this GitHub mirror
+# is good enough
+# https://invent.kde.org/frameworks/syntax-highlighting
+# https://github.com/KDE/syntax-highlighting/blob/master/data/syntax/r.xml
+use_github_file(
+  repo_spec = "KDE/syntax-highlighting",
+  path = "data/syntax/r.xml",
+  save_as = "data-raw/r.xml"
+)
+
+fs::file_copy(
+  "data-raw/r.xml",
+  "inst/rmarkdown/templates/reprex_document/resources/r.xml"
+)
+
+# I then made some edits in the itemDatas section
+# I changed some of the default styles

--- a/data-raw/r.xml
+++ b/data-raw/r.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language>
+<!-- Kate 2.5 (KDE 3.5) highlighting module for R
+	based on an earlier version by E.L. Willighagen. Code folding code by Ben Goodrich
+	version 2.0: (c) 2006 Thomas Friedrichsmeier, Arne Henningsen, and the RKWard Team
+	license: GPL v2
+	Kate   : http://kate.kde.org/
+	R      : http://www.r-project.org/
+	RKWard : http://rkward.kde.org/
+	-->
+<language version="14" kateversion="5.0" name="R Script" section="Scientific" extensions="*.R;*.r;*.S;*.s;*.q" mimetype="" license="GPLv2">
+<highlighting>
+
+	<list name="controls">
+		<item>for</item>
+		<item>in</item>
+		<item>next</item>
+		<item>break</item>
+		<item>while</item>
+		<item>repeat</item>
+		<item>if</item>
+		<item>else</item>
+		<item>switch</item>
+		<item>function</item>
+	</list>
+	<list name="words">
+		<item>TRUE</item>
+		<item>FALSE</item>
+		<item>NULL</item>
+		<item>NA</item>
+		<item>NA_integer_</item>
+		<item>NA_real_</item>
+		<item>NA_complex_</item>
+		<item>NA_character_</item>
+		<item>Inf</item>
+		<item>NaN</item>
+	</list>
+
+	<contexts>
+		<!-- This context is really only good for detecting unexpected closing braces '}'. Since opening braces go to ctx0 (and nesting in there), this context is only active on the base level -->
+		<context attribute="Normal Text" lineEndContext="#stay" name="level0">
+			<IncludeRules context="CommonRules"/>
+
+			<AnyChar attribute="Error" context="#stay" String="})"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="ctx0">
+			<IncludeRules context="CommonRules"/>
+
+			<DetectChar attribute="Symbol" context="#pop" char="}" endRegion="Brace1" />
+			<DetectChar attribute="Error" context="#stay" char=")"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="parenthesis">
+			<LineContinue attribute="Operator" context="#stay"/>
+			<DetectChar attribute="Symbol" context="#pop" char=")"/>
+
+			<RegExpr attribute="Identifier" context="#stay" String="[a-zA-Z_\.][0-9a-zA-Z_\.]*[\s]*[:]?=(?=[^=]|$)"/>
+
+			<IncludeRules context="CommonRules"/>
+			<DetectChar attribute="Error" context="#stay" char="}" />
+		</context>
+
+		<context attribute="String" lineEndContext="#stay" name="string">
+			<DetectChar attribute="String" context="#pop" char="&quot;"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="String" lineEndContext="#stay" name="string2">
+			<DetectChar attribute="String" context="#pop" char="'"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="Identifier" lineEndContext="#stay" name="backquotedsymbol">
+			<DetectChar attribute="String" context="#pop" char="`"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="operator_rhs" fallthrough="true" fallthroughContext="#pop">
+			<!-- While there is nothing of interest, stay in the context -->
+			<DetectSpaces />
+			<IncludeRules context="FindComments"/>
+			<!-- Operators other than +, -, and ! directly after another operator are an error. -->
+			<Detect2Chars attribute="Error" context="#stay" char="!" char1="="/>
+			<AnyChar attribute="Error" context="#stay" String="*/&lt;&gt;=|&amp;:^@$~"/>
+		</context>
+
+		<context attribute="Numeric Suffix" lineEndContext="#pop" name="NumericSuffix" fallthrough="true" fallthroughContext="#pop">
+			<AnyChar attribute="Numeric Suffix" context="#pop" String="Li"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="FindComments">
+			<Detect2Chars attribute="Headline" context="Headline" char="#" char1="#"/>
+			<DetectChar attribute="Comment" context="Comment" char="#"/>
+		</context>
+		<context attribute="Headline" lineEndContext="#pop" name="Headline">
+			<DetectSpaces />
+			<IncludeRules context="##Comments" />
+		</context>
+		<context attribute="Comment" lineEndContext="#pop" name="Comment">
+			<DetectSpaces />
+			<IncludeRules context="##Comments" />
+		</context>
+
+		<!-- This context is not really used, but contains the common rules -->
+		<context name="CommonRules" lineEndContext="#stay" attribute="Normal Text" >
+			<DetectSpaces />
+			<IncludeRules context="FindComments"/>
+			<DetectChar attribute="String" context="string" char="&quot;"/>
+			<DetectChar attribute="String" context="string2" char="'"/>
+			<DetectChar attribute="String" context="backquotedsymbol" char="`"/>
+			<keyword attribute="Control Structure" context="#stay" String="controls"/>
+			<keyword attribute="Reserved Words" context="#stay" String="words"/>
+			<Float attribute="Float" context="#stay"/>
+			<Int attribute="Int" context="NumericSuffix"/>
+			<RegExpr attribute="Keyword" context="#stay" String="[a-zA-Z_]+[a-zA-Z_\.0-9]*(?=[\s]*[(])|\.[a-zA-Z_\.]+[a-zA-Z_\.0-9]*(?=[\s]*[(])"/>
+			<DetectChar attribute="Symbol" context="parenthesis" char="("/>
+
+			<!-- For (assignment) operators, enter a new context operator_rhs to check what follows (generally, that should not be another op) -->
+			<StringDetect attribute="Assign" context="operator_rhs" String="&lt;&lt;-"/>
+			<Detect2Chars attribute="Assign" context="operator_rhs" char="&lt;" char1="-"/>
+			<StringDetect attribute="Assign" context="operator_rhs" String="-&gt;&gt;"/>
+			<Detect2Chars attribute="Assign" context="operator_rhs" char="-" char1="&gt;"/>
+			<RegExpr attribute="Assign" context="operator_rhs" String="=(?!(=|&gt;))"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="*" char1="*"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&lt;" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&gt;" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="=" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="=" char1="&gt;"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="!" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="|" char1="&gt;"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="|" char1="|"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&amp;" char1="&amp;"/>
+			<StringDetect attribute="Operator" context="operator_rhs" String=":::"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char=":" char1=":"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char=":" char1="="/>
+			<AnyChar attribute="Operator" context="operator_rhs" String="+-*/&lt;&gt;=!|&amp;:^@$~"/>
+			<RangeDetect attribute="Operator" context="operator_rhs" char="%" char1="%"/>
+
+			<DetectChar attribute="Symbol" context="ctx0" char="{" beginRegion="Brace1" />
+
+			<!-- This is needed only to assist variable based indentation -->
+			<AnyChar attribute="Symbol" context="#stay" String="[]" />
+		</context>
+	</contexts>
+
+	<itemDatas>
+		<itemData name="Normal Text" defStyleNum="dsNormal" spellChecking="false"/>
+		<itemData name="Symbol" defStyleNum="dsNormal" spellChecking="false"/>
+		<itemData name="Keyword" defStyleNum="dsFunction" spellChecking="false"/>
+		<itemData name="Identifier" defStyleNum="dsAttribute" spellChecking="false"/>
+		<itemData name="String" defStyleNum="dsString"/>
+		<itemData name="Headline" defStyleNum="dsDocumentation" bold="1"/>
+		<itemData name="Comment" defStyleNum="dsComment"/>
+		<itemData name="Assign" defStyleNum="dsOthers" bold="1" italic="0" spellChecking="false"/>
+		<itemData name="Control Structure" defStyleNum="dsControlFlow" spellChecking="false"/>
+		<itemData name="Reserved Words" defStyleNum="dsConstant" spellChecking="false"/>
+		<itemData name="Error" defStyleNum="dsError" spellChecking="false"/>
+		<itemData name="Operator" defStyleNum="dsSpecialChar" spellChecking="false"/>
+		<itemData name="String Char"  defStyleNum="dsSpecialChar" spellChecking="false"/>
+		<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
+		<itemData name="Int" defStyleNum="dsDecVal" spellChecking="false"/>
+		<itemData name="Numeric Suffix" defStyleNum="dsDataType" spellChecking="false"/>
+	</itemDatas>
+</highlighting>
+
+<general>
+	<comments>
+		<comment name="singleLine" start="#"/>
+	</comments>
+	<keywords casesensitive="true" weakDeliminator="." additionalDeliminator="$"/>
+</general>
+</language>
+<!-- kate: replace-tabs off; -->

--- a/data-raw/starry-night-dark.css
+++ b/data-raw/starry-night-dark.css
@@ -1,0 +1,155 @@
+/* This is a theme distributed by `starry-night`.
+ * It’s based on what GitHub uses on their site.
+ * See <https://github.com/wooorm/starry-night> for more info. */
+:root {
+  --color-prettylights-syntax-comment: #9198a1;
+  --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+  --color-prettylights-syntax-entity: #d2a8ff;
+  --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+  --color-prettylights-syntax-entity-tag: #7ee787;
+  --color-prettylights-syntax-keyword: #ff7b72;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-variable: #ffa657;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-markup-list: #f2cc60;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
+  --color-prettylights-syntax-markup-italic: #f0f6fc;
+  --color-prettylights-syntax-markup-bold: #f0f6fc;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+  --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+}
+
+.pl-c {
+  color: var(--color-prettylights-syntax-comment);
+}
+
+.pl-c1,
+.pl-s .pl-v {
+  color: var(--color-prettylights-syntax-constant);
+}
+
+.pl-e,
+.pl-en {
+  color: var(--color-prettylights-syntax-entity);
+}
+
+.pl-smi,
+.pl-s .pl-s1 {
+  color: var(--color-prettylights-syntax-storage-modifier-import);
+}
+
+.pl-ent {
+  color: var(--color-prettylights-syntax-entity-tag);
+}
+
+.pl-k {
+  color: var(--color-prettylights-syntax-keyword);
+}
+
+.pl-s,
+.pl-pds,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sre,
+.pl-sr .pl-sra {
+  color: var(--color-prettylights-syntax-string);
+}
+
+.pl-v,
+.pl-smw {
+  color: var(--color-prettylights-syntax-variable);
+}
+
+.pl-bu {
+  color: var(--color-prettylights-syntax-brackethighlighter-unmatched);
+}
+
+.pl-ii {
+  color: var(--color-prettylights-syntax-invalid-illegal-text);
+  background-color: var(--color-prettylights-syntax-invalid-illegal-bg);
+}
+
+.pl-c2 {
+  color: var(--color-prettylights-syntax-carriage-return-text);
+  background-color: var(--color-prettylights-syntax-carriage-return-bg);
+}
+
+.pl-sr .pl-cce {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-string-regexp);
+}
+
+.pl-ml {
+  color: var(--color-prettylights-syntax-markup-list);
+}
+
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-heading);
+}
+
+.pl-mi {
+  font-style: italic;
+  color: var(--color-prettylights-syntax-markup-italic);
+}
+
+.pl-mb {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-bold);
+}
+
+.pl-md {
+  color: var(--color-prettylights-syntax-markup-deleted-text);
+  background-color: var(--color-prettylights-syntax-markup-deleted-bg);
+}
+
+.pl-mi1 {
+  color: var(--color-prettylights-syntax-markup-inserted-text);
+  background-color: var(--color-prettylights-syntax-markup-inserted-bg);
+}
+
+.pl-mc {
+  color: var(--color-prettylights-syntax-markup-changed-text);
+  background-color: var(--color-prettylights-syntax-markup-changed-bg);
+}
+
+.pl-mi2 {
+  color: var(--color-prettylights-syntax-markup-ignored-text);
+  background-color: var(--color-prettylights-syntax-markup-ignored-bg);
+}
+
+.pl-mdr {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-meta-diff-range);
+}
+
+.pl-ba {
+  color: var(--color-prettylights-syntax-brackethighlighter-angle);
+}
+
+.pl-sg {
+  color: var(--color-prettylights-syntax-sublimelinter-gutter-mark);
+}
+
+.pl-corl {
+  text-decoration: underline;
+  color: var(--color-prettylights-syntax-constant-other-reference-link);
+}

--- a/data-raw/starry-night-light.css
+++ b/data-raw/starry-night-light.css
@@ -1,0 +1,155 @@
+/* This is a theme distributed by `starry-night`.
+ * It’s based on what GitHub uses on their site.
+ * See <https://github.com/wooorm/starry-night> for more info. */
+:root {
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
+  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-variable: #953800;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
+  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-carriage-return-bg: #cf222e;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+}
+
+.pl-c {
+  color: var(--color-prettylights-syntax-comment);
+}
+
+.pl-c1,
+.pl-s .pl-v {
+  color: var(--color-prettylights-syntax-constant);
+}
+
+.pl-e,
+.pl-en {
+  color: var(--color-prettylights-syntax-entity);
+}
+
+.pl-smi,
+.pl-s .pl-s1 {
+  color: var(--color-prettylights-syntax-storage-modifier-import);
+}
+
+.pl-ent {
+  color: var(--color-prettylights-syntax-entity-tag);
+}
+
+.pl-k {
+  color: var(--color-prettylights-syntax-keyword);
+}
+
+.pl-s,
+.pl-pds,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sre,
+.pl-sr .pl-sra {
+  color: var(--color-prettylights-syntax-string);
+}
+
+.pl-v,
+.pl-smw {
+  color: var(--color-prettylights-syntax-variable);
+}
+
+.pl-bu {
+  color: var(--color-prettylights-syntax-brackethighlighter-unmatched);
+}
+
+.pl-ii {
+  color: var(--color-prettylights-syntax-invalid-illegal-text);
+  background-color: var(--color-prettylights-syntax-invalid-illegal-bg);
+}
+
+.pl-c2 {
+  color: var(--color-prettylights-syntax-carriage-return-text);
+  background-color: var(--color-prettylights-syntax-carriage-return-bg);
+}
+
+.pl-sr .pl-cce {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-string-regexp);
+}
+
+.pl-ml {
+  color: var(--color-prettylights-syntax-markup-list);
+}
+
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-heading);
+}
+
+.pl-mi {
+  font-style: italic;
+  color: var(--color-prettylights-syntax-markup-italic);
+}
+
+.pl-mb {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-bold);
+}
+
+.pl-md {
+  color: var(--color-prettylights-syntax-markup-deleted-text);
+  background-color: var(--color-prettylights-syntax-markup-deleted-bg);
+}
+
+.pl-mi1 {
+  color: var(--color-prettylights-syntax-markup-inserted-text);
+  background-color: var(--color-prettylights-syntax-markup-inserted-bg);
+}
+
+.pl-mc {
+  color: var(--color-prettylights-syntax-markup-changed-text);
+  background-color: var(--color-prettylights-syntax-markup-changed-bg);
+}
+
+.pl-mi2 {
+  color: var(--color-prettylights-syntax-markup-ignored-text);
+  background-color: var(--color-prettylights-syntax-markup-ignored-bg);
+}
+
+.pl-mdr {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-meta-diff-range);
+}
+
+.pl-ba {
+  color: var(--color-prettylights-syntax-brackethighlighter-angle);
+}
+
+.pl-sg {
+  color: var(--color-prettylights-syntax-sublimelinter-gutter-mark);
+}
+
+.pl-corl {
+  text-decoration: underline;
+  color: var(--color-prettylights-syntax-constant-other-reference-link);
+}

--- a/inst/rmarkdown/templates/reprex_document/resources/github-dark.css
+++ b/inst/rmarkdown/templates/reprex_document/resources/github-dark.css
@@ -1,0 +1,1103 @@
+/*dark*/
+
+.markdown-body {
+  color-scheme: dark;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  color: #e6edf3;
+  background-color: #0d1117;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+  scroll-behavior: auto;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  fill: currentColor;
+  vertical-align: text-bottom;
+}
+
+.markdown-body h1:hover .anchor .octicon-link:before,
+.markdown-body h2:hover .anchor .octicon-link:before,
+.markdown-body h3:hover .anchor .octicon-link:before,
+.markdown-body h4:hover .anchor .octicon-link:before,
+.markdown-body h5:hover .anchor .octicon-link:before,
+.markdown-body h6:hover .anchor .octicon-link:before {
+  width: 16px;
+  height: 16px;
+  content: ' ';
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: transparent;
+  color: #4493f8;
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: 600;
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: 1px solid #30363db3;
+}
+
+.markdown-body mark {
+  background-color: #bb800926;
+  color: #e6edf3;
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: #0d1117;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: monospace;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em 40px;
+}
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid #30363db3;
+  height: .25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: #30363d;
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  -webkit-appearance: button;
+  appearance: button;
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body [type=number]::-webkit-inner-spin-button,
+.markdown-body [type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type=search]::-webkit-search-cancel-button,
+.markdown-body [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+
+.markdown-body ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body ::placeholder {
+  color: #8d96a0;
+  opacity: 1;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body details:not([open])>*:not(summary) {
+  display: none;
+}
+
+.markdown-body a:focus,
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
+  outline: 2px solid #1f6feb;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+  outline: solid 1px transparent;
+}
+
+.markdown-body a:focus-visible,
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline: 2px solid #1f6feb;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:not([class]):focus,
+.markdown-body a:not([class]):focus-visible,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline-offset: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  line-height: 10px;
+  color: #e6edf3;
+  vertical-align: middle;
+  background-color: #161b22;
+  border: solid 1px #6e768166;
+  border-bottom-color: #6e768166;
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 #6e768166;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid #30363db3;
+}
+
+.markdown-body h3 {
+  font-weight: 600;
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: 600;
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: 600;
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: 600;
+  font-size: .85em;
+  color: #8d96a0;
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #8d96a0;
+  border-left: .25em solid #30363d;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  word-wrap: normal;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body input::-webkit-outer-spin-button,
+.markdown-body input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body .mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: #f85149;
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  outline: none;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: #e6edf3;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: 16px;
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+.markdown-body dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.markdown-body table th {
+  font-weight: 600;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #30363d;
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: #0d1117;
+  border-top: 1px solid #30363db3;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #161b22;
+}
+
+.markdown-body table img {
+  background-color: transparent;
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: transparent;
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid #30363d;
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: #e6edf3;
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: #6e768166;
+  border-radius: 6px;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: 16px;
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: #e6edf3;
+  background-color: #161b22;
+  border-radius: 6px;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px 8px 9px;
+  text-align: right;
+  background: #0d1117;
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: 600;
+  background: #161b22;
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: #8d96a0;
+  border-top: 1px solid #30363d;
+}
+
+.markdown-body .footnotes ol {
+  padding-left: 16px;
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: 16px;
+  margin-top: 16px;
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .footnotes li:target::before {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  left: -24px;
+  pointer-events: none;
+  content: "";
+  border: 2px solid #1f6feb;
+  border-radius: 6px;
+}
+
+.markdown-body .footnotes li:target {
+  color: #e6edf3;
+}
+
+.markdown-body .footnotes .data-footnote-backref g-emoji {
+  font-family: monospace;
+}
+
+.markdown-body .pl-c {
+  color: #8b949e;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: #79c0ff;
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: #d2a8ff;
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: #c9d1d9;
+}
+
+.markdown-body .pl-ent {
+  color: #7ee787;
+}
+
+.markdown-body .pl-k {
+  color: #ff7b72;
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: #a5d6ff;
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: #ffa657;
+}
+
+.markdown-body .pl-bu {
+  color: #f85149;
+}
+
+.markdown-body .pl-ii {
+  color: #f0f6fc;
+  background-color: #8e1519;
+}
+
+.markdown-body .pl-c2 {
+  color: #f0f6fc;
+  background-color: #b62324;
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: #7ee787;
+}
+
+.markdown-body .pl-ml {
+  color: #f2cc60;
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: #1f6feb;
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: #c9d1d9;
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: #c9d1d9;
+}
+
+.markdown-body .pl-md {
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.markdown-body .pl-mi1 {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.markdown-body .pl-mc {
+  color: #ffdfb6;
+  background-color: #5a1e02;
+}
+
+.markdown-body .pl-mi2 {
+  color: #c9d1d9;
+  background-color: #1158c7;
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: #d2a8ff;
+}
+
+.markdown-body .pl-ba {
+  color: #8b949e;
+}
+
+.markdown-body .pl-sg {
+  color: #484f58;
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: #a5d6ff;
+}
+
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  min-width: 1ch;
+  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: 400;
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: 400;
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: 0.25rem;
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body .contains-task-list:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body .contains-task-list {
+  position: relative;
+}
+
+.markdown-body .contains-task-list:hover .task-list-item-convert-container,
+.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip: auto;
+}
+
+.markdown-body ::-webkit-calendar-picker-indicator {
+  filter: invert(50%);
+}
+
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  color: inherit;
+  border-left: .25em solid #30363d;
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  font-weight: 500;
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: #1f6feb;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: #4493f8;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: #8957e5;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: #ab7df8;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: #9e6a03;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: #d29922;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: #238636;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: #3fb950;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: #da3633;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: #f85149;
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}

--- a/inst/rmarkdown/templates/reprex_document/resources/github-dark.css
+++ b/inst/rmarkdown/templates/reprex_document/resources/github-dark.css
@@ -1,6 +1,6 @@
 /*dark*/
 
-.markdown-body {
+body {
   color-scheme: dark;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -14,18 +14,28 @@
   scroll-behavior: auto;
 }
 
-.markdown-body .octicon {
+/* reprex tweaks */
+body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+  padding-top: 15px;
+}
+
+.octicon {
   display: inline-block;
   fill: currentColor;
   vertical-align: text-bottom;
 }
 
-.markdown-body h1:hover .anchor .octicon-link:before,
-.markdown-body h2:hover .anchor .octicon-link:before,
-.markdown-body h3:hover .anchor .octicon-link:before,
-.markdown-body h4:hover .anchor .octicon-link:before,
-.markdown-body h5:hover .anchor .octicon-link:before,
-.markdown-body h6:hover .anchor .octicon-link:before {
+h1:hover .anchor .octicon-link:before,
+h2:hover .anchor .octicon-link:before,
+h3:hover .anchor .octicon-link:before,
+h4:hover .anchor .octicon-link:before,
+h5:hover .anchor .octicon-link:before,
+h6:hover .anchor .octicon-link:before {
   width: 16px;
   height: 16px;
   content: ' ';
@@ -35,42 +45,42 @@
   mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
 }
 
-.markdown-body details,
-.markdown-body figcaption,
-.markdown-body figure {
+details,
+figcaption,
+figure {
   display: block;
 }
 
-.markdown-body summary {
+summary {
   display: list-item;
 }
 
-.markdown-body [hidden] {
+[hidden] {
   display: none !important;
 }
 
-.markdown-body a {
+a {
   background-color: transparent;
   color: #4493f8;
   text-decoration: none;
 }
 
-.markdown-body abbr[title] {
+abbr[title] {
   border-bottom: none;
   -webkit-text-decoration: underline dotted;
   text-decoration: underline dotted;
 }
 
-.markdown-body b,
-.markdown-body strong {
+b,
+strong {
   font-weight: 600;
 }
 
-.markdown-body dfn {
+dfn {
   font-style: italic;
 }
 
-.markdown-body h1 {
+h1 {
   margin: .67em 0;
   font-weight: 600;
   padding-bottom: .3em;
@@ -78,51 +88,51 @@
   border-bottom: 1px solid #30363db3;
 }
 
-.markdown-body mark {
+mark {
   background-color: #bb800926;
   color: #e6edf3;
 }
 
-.markdown-body small {
+small {
   font-size: 90%;
 }
 
-.markdown-body sub,
-.markdown-body sup {
+sub,
+sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
   vertical-align: baseline;
 }
 
-.markdown-body sub {
+sub {
   bottom: -0.25em;
 }
 
-.markdown-body sup {
+sup {
   top: -0.5em;
 }
 
-.markdown-body img {
+img {
   border-style: none;
   max-width: 100%;
   box-sizing: content-box;
   background-color: #0d1117;
 }
 
-.markdown-body code,
-.markdown-body kbd,
-.markdown-body pre,
-.markdown-body samp {
+code,
+kbd,
+pre,
+samp {
   font-family: monospace;
   font-size: 1em;
 }
 
-.markdown-body figure {
+figure {
   margin: 1em 40px;
 }
 
-.markdown-body hr {
+hr {
   box-sizing: content-box;
   overflow: hidden;
   background: transparent;
@@ -134,7 +144,7 @@
   border: 0;
 }
 
-.markdown-body input {
+input {
   font: inherit;
   margin: 0;
   overflow: visible;
@@ -143,62 +153,62 @@
   line-height: inherit;
 }
 
-.markdown-body [type=button],
-.markdown-body [type=reset],
-.markdown-body [type=submit] {
+[type=button],
+[type=reset],
+[type=submit] {
   -webkit-appearance: button;
   appearance: button;
 }
 
-.markdown-body [type=checkbox],
-.markdown-body [type=radio] {
+[type=checkbox],
+[type=radio] {
   box-sizing: border-box;
   padding: 0;
 }
 
-.markdown-body [type=number]::-webkit-inner-spin-button,
-.markdown-body [type=number]::-webkit-outer-spin-button {
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
-.markdown-body [type=search]::-webkit-search-cancel-button,
-.markdown-body [type=search]::-webkit-search-decoration {
+[type=search]::-webkit-search-cancel-button,
+[type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }
 
-.markdown-body ::-webkit-input-placeholder {
+::-webkit-input-placeholder {
   color: inherit;
   opacity: .54;
 }
 
-.markdown-body ::-webkit-file-upload-button {
+::-webkit-file-upload-button {
   -webkit-appearance: button;
   appearance: button;
   font: inherit;
 }
 
-.markdown-body a:hover {
+a:hover {
   text-decoration: underline;
 }
 
-.markdown-body ::placeholder {
+::placeholder {
   color: #8d96a0;
   opacity: 1;
 }
 
-.markdown-body hr::before {
+hr::before {
   display: table;
   content: "";
 }
 
-.markdown-body hr::after {
+hr::after {
   display: table;
   clear: both;
   content: "";
 }
 
-.markdown-body table {
+table {
   border-spacing: 0;
   border-collapse: collapse;
   display: block;
@@ -207,54 +217,54 @@
   overflow: auto;
 }
 
-.markdown-body td,
-.markdown-body th {
+td,
+th {
   padding: 0;
 }
 
-.markdown-body details summary {
+details summary {
   cursor: pointer;
 }
 
-.markdown-body details:not([open])>*:not(summary) {
+details:not([open])>*:not(summary) {
   display: none;
 }
 
-.markdown-body a:focus,
-.markdown-body [role=button]:focus,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=checkbox]:focus {
+a:focus,
+[role=button]:focus,
+input[type=radio]:focus,
+input[type=checkbox]:focus {
   outline: 2px solid #1f6feb;
   outline-offset: -2px;
   box-shadow: none;
 }
 
-.markdown-body a:focus:not(:focus-visible),
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body input[type=radio]:focus:not(:focus-visible),
-.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+a:focus:not(:focus-visible),
+[role=button]:focus:not(:focus-visible),
+input[type=radio]:focus:not(:focus-visible),
+input[type=checkbox]:focus:not(:focus-visible) {
   outline: solid 1px transparent;
 }
 
-.markdown-body a:focus-visible,
-.markdown-body [role=button]:focus-visible,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus-visible {
+a:focus-visible,
+[role=button]:focus-visible,
+input[type=radio]:focus-visible,
+input[type=checkbox]:focus-visible {
   outline: 2px solid #1f6feb;
   outline-offset: -2px;
   box-shadow: none;
 }
 
-.markdown-body a:not([class]):focus,
-.markdown-body a:not([class]):focus-visible,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus,
-.markdown-body input[type=checkbox]:focus-visible {
+a:not([class]):focus,
+a:not([class]):focus-visible,
+input[type=radio]:focus,
+input[type=radio]:focus-visible,
+input[type=checkbox]:focus,
+input[type=checkbox]:focus-visible {
   outline-offset: 0;
 }
 
-.markdown-body kbd {
+kbd {
   display: inline-block;
   padding: 3px 5px;
   font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
@@ -268,89 +278,89 @@
   box-shadow: inset 0 -1px 0 #6e768166;
 }
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin-top: 24px;
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
 }
 
-.markdown-body h2 {
+h2 {
   font-weight: 600;
   padding-bottom: .3em;
   font-size: 1.5em;
   border-bottom: 1px solid #30363db3;
 }
 
-.markdown-body h3 {
+h3 {
   font-weight: 600;
   font-size: 1.25em;
 }
 
-.markdown-body h4 {
+h4 {
   font-weight: 600;
   font-size: 1em;
 }
 
-.markdown-body h5 {
+h5 {
   font-weight: 600;
   font-size: .875em;
 }
 
-.markdown-body h6 {
+h6 {
   font-weight: 600;
   font-size: .85em;
   color: #8d96a0;
 }
 
-.markdown-body p {
+p {
   margin-top: 0;
   margin-bottom: 10px;
 }
 
-.markdown-body blockquote {
+blockquote {
   margin: 0;
   padding: 0 1em;
   color: #8d96a0;
   border-left: .25em solid #30363d;
 }
 
-.markdown-body ul,
-.markdown-body ol {
+ul,
+ol {
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;
 }
 
-.markdown-body ol ol,
-.markdown-body ul ol {
+ol ol,
+ul ol {
   list-style-type: lower-roman;
 }
 
-.markdown-body ul ul ol,
-.markdown-body ul ol ol,
-.markdown-body ol ul ol,
-.markdown-body ol ol ol {
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
   list-style-type: lower-alpha;
 }
 
-.markdown-body dd {
+dd {
   margin-left: 0;
 }
 
-.markdown-body tt,
-.markdown-body code,
-.markdown-body samp {
+tt,
+code,
+samp {
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   font-size: 12px;
 }
 
-.markdown-body pre {
+pre {
   margin-top: 0;
   margin-bottom: 0;
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
@@ -358,21 +368,21 @@
   word-wrap: normal;
 }
 
-.markdown-body .octicon {
+.octicon {
   display: inline-block;
   overflow: visible !important;
   vertical-align: text-bottom;
   fill: currentColor;
 }
 
-.markdown-body input::-webkit-outer-spin-button,
-.markdown-body input::-webkit-inner-spin-button {
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   appearance: none;
 }
 
-.markdown-body .mr-2 {
+.mr-2 {
   margin-right: 0.5rem !important;
 }
 
@@ -395,166 +405,166 @@
   margin-bottom: 0 !important;
 }
 
-.markdown-body a:not([href]) {
+a:not([href]) {
   color: inherit;
   text-decoration: none;
 }
 
-.markdown-body .absent {
+.absent {
   color: #f85149;
 }
 
-.markdown-body .anchor {
+.anchor {
   float: left;
   padding-right: 4px;
   margin-left: -20px;
   line-height: 1;
 }
 
-.markdown-body .anchor:focus {
+.anchor:focus {
   outline: none;
 }
 
-.markdown-body p,
-.markdown-body blockquote,
-.markdown-body ul,
-.markdown-body ol,
-.markdown-body dl,
-.markdown-body table,
-.markdown-body pre,
-.markdown-body details {
+p,
+blockquote,
+ul,
+ol,
+dl,
+table,
+pre,
+details {
   margin-top: 0;
   margin-bottom: 16px;
 }
 
-.markdown-body blockquote>:first-child {
+blockquote>:first-child {
   margin-top: 0;
 }
 
-.markdown-body blockquote>:last-child {
+blockquote>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
+h1 .octicon-link,
+h2 .octicon-link,
+h3 .octicon-link,
+h4 .octicon-link,
+h5 .octicon-link,
+h6 .octicon-link {
   color: #e6edf3;
   vertical-align: middle;
   visibility: hidden;
 }
 
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
   text-decoration: none;
 }
 
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
+h1:hover .anchor .octicon-link,
+h2:hover .anchor .octicon-link,
+h3:hover .anchor .octicon-link,
+h4:hover .anchor .octicon-link,
+h5:hover .anchor .octicon-link,
+h6:hover .anchor .octicon-link {
   visibility: visible;
 }
 
-.markdown-body h1 tt,
-.markdown-body h1 code,
-.markdown-body h2 tt,
-.markdown-body h2 code,
-.markdown-body h3 tt,
-.markdown-body h3 code,
-.markdown-body h4 tt,
-.markdown-body h4 code,
-.markdown-body h5 tt,
-.markdown-body h5 code,
-.markdown-body h6 tt,
-.markdown-body h6 code {
+h1 tt,
+h1 code,
+h2 tt,
+h2 code,
+h3 tt,
+h3 code,
+h4 tt,
+h4 code,
+h5 tt,
+h5 code,
+h6 tt,
+h6 code {
   padding: 0 .2em;
   font-size: inherit;
 }
 
-.markdown-body summary h1,
-.markdown-body summary h2,
-.markdown-body summary h3,
-.markdown-body summary h4,
-.markdown-body summary h5,
-.markdown-body summary h6 {
+summary h1,
+summary h2,
+summary h3,
+summary h4,
+summary h5,
+summary h6 {
   display: inline-block;
 }
 
-.markdown-body summary h1 .anchor,
-.markdown-body summary h2 .anchor,
-.markdown-body summary h3 .anchor,
-.markdown-body summary h4 .anchor,
-.markdown-body summary h5 .anchor,
-.markdown-body summary h6 .anchor {
+summary h1 .anchor,
+summary h2 .anchor,
+summary h3 .anchor,
+summary h4 .anchor,
+summary h5 .anchor,
+summary h6 .anchor {
   margin-left: -40px;
 }
 
-.markdown-body summary h1,
-.markdown-body summary h2 {
+summary h1,
+summary h2 {
   padding-bottom: 0;
   border-bottom: 0;
 }
 
-.markdown-body ul.no-list,
-.markdown-body ol.no-list {
+ul.no-list,
+ol.no-list {
   padding: 0;
   list-style-type: none;
 }
 
-.markdown-body ol[type="a s"] {
+ol[type="a s"] {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type="A s"] {
+ol[type="A s"] {
   list-style-type: upper-alpha;
 }
 
-.markdown-body ol[type="i s"] {
+ol[type="i s"] {
   list-style-type: lower-roman;
 }
 
-.markdown-body ol[type="I s"] {
+ol[type="I s"] {
   list-style-type: upper-roman;
 }
 
-.markdown-body ol[type="1"] {
+ol[type="1"] {
   list-style-type: decimal;
 }
 
-.markdown-body div>ol:not([type]) {
+div>ol:not([type]) {
   list-style-type: decimal;
 }
 
-.markdown-body ul ul,
-.markdown-body ul ol,
-.markdown-body ol ol,
-.markdown-body ol ul {
+ul ul,
+ul ol,
+ol ol,
+ol ul {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.markdown-body li>p {
+li>p {
   margin-top: 16px;
 }
 
-.markdown-body li+li {
+li+li {
   margin-top: .25em;
 }
 
-.markdown-body dl {
+dl {
   padding: 0;
 }
 
-.markdown-body dl dt {
+dl dt {
   padding: 0;
   margin-top: 16px;
   font-size: 1em;
@@ -562,58 +572,58 @@
   font-weight: 600;
 }
 
-.markdown-body dl dd {
+dl dd {
   padding: 0 16px;
   margin-bottom: 16px;
 }
 
-.markdown-body table th {
+table th {
   font-weight: 600;
 }
 
-.markdown-body table th,
-.markdown-body table td {
+table th,
+table td {
   padding: 6px 13px;
   border: 1px solid #30363d;
 }
 
-.markdown-body table td>:last-child {
+table td>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body table tr {
+table tr {
   background-color: #0d1117;
   border-top: 1px solid #30363db3;
 }
 
-.markdown-body table tr:nth-child(2n) {
+table tr:nth-child(2n) {
   background-color: #161b22;
 }
 
-.markdown-body table img {
+table img {
   background-color: transparent;
 }
 
-.markdown-body img[align=right] {
+img[align=right] {
   padding-left: 20px;
 }
 
-.markdown-body img[align=left] {
+img[align=left] {
   padding-right: 20px;
 }
 
-.markdown-body .emoji {
+.emoji {
   max-width: none;
   vertical-align: text-top;
   background-color: transparent;
 }
 
-.markdown-body span.frame {
+span.frame {
   display: block;
   overflow: hidden;
 }
 
-.markdown-body span.frame>span {
+span.frame>span {
   display: block;
   float: left;
   width: auto;
@@ -623,81 +633,81 @@
   border: 1px solid #30363d;
 }
 
-.markdown-body span.frame span img {
+span.frame span img {
   display: block;
   float: left;
 }
 
-.markdown-body span.frame span span {
+span.frame span span {
   display: block;
   padding: 5px 0 0;
   clear: both;
   color: #e6edf3;
 }
 
-.markdown-body span.align-center {
+span.align-center {
   display: block;
   overflow: hidden;
   clear: both;
 }
 
-.markdown-body span.align-center>span {
+span.align-center>span {
   display: block;
   margin: 13px auto 0;
   overflow: hidden;
   text-align: center;
 }
 
-.markdown-body span.align-center span img {
+span.align-center span img {
   margin: 0 auto;
   text-align: center;
 }
 
-.markdown-body span.align-right {
+span.align-right {
   display: block;
   overflow: hidden;
   clear: both;
 }
 
-.markdown-body span.align-right>span {
+span.align-right>span {
   display: block;
   margin: 13px 0 0;
   overflow: hidden;
   text-align: right;
 }
 
-.markdown-body span.align-right span img {
+span.align-right span img {
   margin: 0;
   text-align: right;
 }
 
-.markdown-body span.float-left {
+span.float-left {
   display: block;
   float: left;
   margin-right: 13px;
   overflow: hidden;
 }
 
-.markdown-body span.float-left span {
+span.float-left span {
   margin: 13px 0 0;
 }
 
-.markdown-body span.float-right {
+span.float-right {
   display: block;
   float: right;
   margin-left: 13px;
   overflow: hidden;
 }
 
-.markdown-body span.float-right>span {
+span.float-right>span {
   display: block;
   margin: 13px auto 0;
   overflow: hidden;
   text-align: right;
 }
 
-.markdown-body code,
-.markdown-body tt {
+code,
+tt {
   padding: .2em .4em;
   margin: 0;
   font-size: 85%;
@@ -706,24 +716,24 @@
   border-radius: 6px;
 }
 
-.markdown-body code br,
-.markdown-body tt br {
+code br,
+tt br {
   display: none;
 }
 
-.markdown-body del code {
+del code {
   text-decoration: inherit;
 }
 
-.markdown-body samp {
+samp {
   font-size: 85%;
 }
 
-.markdown-body pre code {
+pre code {
   font-size: 100%;
 }
 
-.markdown-body pre>code {
+pre>code {
   padding: 0;
   margin: 0;
   word-break: normal;
@@ -732,17 +742,17 @@
   border: 0;
 }
 
-.markdown-body .highlight {
+.highlight {
   margin-bottom: 16px;
 }
 
-.markdown-body .highlight pre {
+.highlight pre {
   margin-bottom: 0;
   word-break: normal;
 }
 
-.markdown-body .highlight pre,
-.markdown-body pre {
+.highlight pre,
+pre {
   padding: 16px;
   overflow: auto;
   font-size: 85%;
@@ -752,8 +762,8 @@
   border-radius: 6px;
 }
 
-.markdown-body pre code,
-.markdown-body pre tt {
+pre code,
+pre tt {
   display: inline;
   max-width: auto;
   padding: 0;
@@ -765,8 +775,8 @@
   border: 0;
 }
 
-.markdown-body .csv-data td,
-.markdown-body .csv-data th {
+.csv-data td,
+.csv-data th {
   padding: 5px;
   overflow: hidden;
   font-size: 12px;
@@ -775,52 +785,52 @@
   white-space: nowrap;
 }
 
-.markdown-body .csv-data .blob-num {
+.csv-data .blob-num {
   padding: 10px 8px 9px;
   text-align: right;
   background: #0d1117;
   border: 0;
 }
 
-.markdown-body .csv-data tr {
+.csv-data tr {
   border-top: 0;
 }
 
-.markdown-body .csv-data th {
+.csv-data th {
   font-weight: 600;
   background: #161b22;
   border-top: 0;
 }
 
-.markdown-body [data-footnote-ref]::before {
+[data-footnote-ref]::before {
   content: "[";
 }
 
-.markdown-body [data-footnote-ref]::after {
+[data-footnote-ref]::after {
   content: "]";
 }
 
-.markdown-body .footnotes {
+.footnotes {
   font-size: 12px;
   color: #8d96a0;
   border-top: 1px solid #30363d;
 }
 
-.markdown-body .footnotes ol {
+.footnotes ol {
   padding-left: 16px;
 }
 
-.markdown-body .footnotes ol ul {
+.footnotes ol ul {
   display: inline-block;
   padding-left: 16px;
   margin-top: 16px;
 }
 
-.markdown-body .footnotes li {
+.footnotes li {
   position: relative;
 }
 
-.markdown-body .footnotes li:target::before {
+.footnotes li:target::before {
   position: absolute;
   top: -8px;
   right: -8px;
@@ -832,149 +842,149 @@
   border-radius: 6px;
 }
 
-.markdown-body .footnotes li:target {
+.footnotes li:target {
   color: #e6edf3;
 }
 
-.markdown-body .footnotes .data-footnote-backref g-emoji {
+.footnotes .data-footnote-backref g-emoji {
   font-family: monospace;
 }
 
-.markdown-body .pl-c {
+.pl-c {
   color: #8b949e;
 }
 
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
+.pl-c1,
+.pl-s .pl-v {
   color: #79c0ff;
 }
 
-.markdown-body .pl-e,
-.markdown-body .pl-en {
+.pl-e,
+.pl-en {
   color: #d2a8ff;
 }
 
-.markdown-body .pl-smi,
-.markdown-body .pl-s .pl-s1 {
+.pl-smi,
+.pl-s .pl-s1 {
   color: #c9d1d9;
 }
 
-.markdown-body .pl-ent {
+.pl-ent {
   color: #7ee787;
 }
 
-.markdown-body .pl-k {
+.pl-k {
   color: #ff7b72;
 }
 
-.markdown-body .pl-s,
-.markdown-body .pl-pds,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sre,
-.markdown-body .pl-sr .pl-sra {
+.pl-s,
+.pl-pds,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sre,
+.pl-sr .pl-sra {
   color: #a5d6ff;
 }
 
-.markdown-body .pl-v,
-.markdown-body .pl-smw {
+.pl-v,
+.pl-smw {
   color: #ffa657;
 }
 
-.markdown-body .pl-bu {
+.pl-bu {
   color: #f85149;
 }
 
-.markdown-body .pl-ii {
+.pl-ii {
   color: #f0f6fc;
   background-color: #8e1519;
 }
 
-.markdown-body .pl-c2 {
+.pl-c2 {
   color: #f0f6fc;
   background-color: #b62324;
 }
 
-.markdown-body .pl-sr .pl-cce {
+.pl-sr .pl-cce {
   font-weight: bold;
   color: #7ee787;
 }
 
-.markdown-body .pl-ml {
+.pl-ml {
   color: #f2cc60;
 }
 
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
   font-weight: bold;
   color: #1f6feb;
 }
 
-.markdown-body .pl-mi {
+.pl-mi {
   font-style: italic;
   color: #c9d1d9;
 }
 
-.markdown-body .pl-mb {
+.pl-mb {
   font-weight: bold;
   color: #c9d1d9;
 }
 
-.markdown-body .pl-md {
+.pl-md {
   color: #ffdcd7;
   background-color: #67060c;
 }
 
-.markdown-body .pl-mi1 {
+.pl-mi1 {
   color: #aff5b4;
   background-color: #033a16;
 }
 
-.markdown-body .pl-mc {
+.pl-mc {
   color: #ffdfb6;
   background-color: #5a1e02;
 }
 
-.markdown-body .pl-mi2 {
+.pl-mi2 {
   color: #c9d1d9;
   background-color: #1158c7;
 }
 
-.markdown-body .pl-mdr {
+.pl-mdr {
   font-weight: bold;
   color: #d2a8ff;
 }
 
-.markdown-body .pl-ba {
+.pl-ba {
   color: #8b949e;
 }
 
-.markdown-body .pl-sg {
+.pl-sg {
   color: #484f58;
 }
 
-.markdown-body .pl-corl {
+.pl-corl {
   text-decoration: underline;
   color: #a5d6ff;
 }
 
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
-.markdown-body button:focus:not(:focus-visible),
-.markdown-body summary:focus:not(:focus-visible),
-.markdown-body a:focus:not(:focus-visible) {
+[role=button]:focus:not(:focus-visible),
+[role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+button:focus:not(:focus-visible),
+summary:focus:not(:focus-visible),
+a:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.markdown-body [tabindex="0"]:focus:not(:focus-visible),
-.markdown-body details-dialog:focus:not(:focus-visible) {
+[tabindex="0"]:focus:not(:focus-visible),
+details-dialog:focus:not(:focus-visible) {
   outline: none;
 }
 
-.markdown-body g-emoji {
+g-emoji {
   display: inline-block;
   min-width: 1ch;
   font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -985,46 +995,46 @@
   vertical-align: -0.075em;
 }
 
-.markdown-body g-emoji img {
+g-emoji img {
   width: 1em;
   height: 1em;
 }
 
-.markdown-body .task-list-item {
+.task-list-item {
   list-style-type: none;
 }
 
-.markdown-body .task-list-item label {
+.task-list-item label {
   font-weight: 400;
 }
 
-.markdown-body .task-list-item.enabled label {
+.task-list-item.enabled label {
   cursor: pointer;
 }
 
-.markdown-body .task-list-item+.task-list-item {
+.task-list-item+.task-list-item {
   margin-top: 0.25rem;
 }
 
-.markdown-body .task-list-item .handle {
+.task-list-item .handle {
   display: none;
 }
 
-.markdown-body .task-list-item-checkbox {
+.task-list-item-checkbox {
   margin: 0 .2em .25em -1.4em;
   vertical-align: middle;
 }
 
-.markdown-body .contains-task-list:dir(rtl) .task-list-item-checkbox {
+.contains-task-list:dir(rtl) .task-list-item-checkbox {
   margin: 0 -1.6em .25em .2em;
 }
 
-.markdown-body .contains-task-list {
+.contains-task-list {
   position: relative;
 }
 
-.markdown-body .contains-task-list:hover .task-list-item-convert-container,
-.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+.contains-task-list:hover .task-list-item-convert-container,
+.contains-task-list:focus-within .task-list-item-convert-container {
   display: block;
   width: auto;
   height: 24px;
@@ -1032,69 +1042,69 @@
   clip: auto;
 }
 
-.markdown-body ::-webkit-calendar-picker-indicator {
+::-webkit-calendar-picker-indicator {
   filter: invert(50%);
 }
 
-.markdown-body .markdown-alert {
+.markdown-alert {
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
   color: inherit;
   border-left: .25em solid #30363d;
 }
 
-.markdown-body .markdown-alert>:first-child {
+.markdown-alert>:first-child {
   margin-top: 0;
 }
 
-.markdown-body .markdown-alert>:last-child {
+.markdown-alert>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body .markdown-alert .markdown-alert-title {
+.markdown-alert .markdown-alert-title {
   display: flex;
   font-weight: 500;
   align-items: center;
   line-height: 1;
 }
 
-.markdown-body .markdown-alert.markdown-alert-note {
+.markdown-alert.markdown-alert-note {
   border-left-color: #1f6feb;
 }
 
-.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+.markdown-alert.markdown-alert-note .markdown-alert-title {
   color: #4493f8;
 }
 
-.markdown-body .markdown-alert.markdown-alert-important {
+.markdown-alert.markdown-alert-important {
   border-left-color: #8957e5;
 }
 
-.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+.markdown-alert.markdown-alert-important .markdown-alert-title {
   color: #ab7df8;
 }
 
-.markdown-body .markdown-alert.markdown-alert-warning {
+.markdown-alert.markdown-alert-warning {
   border-left-color: #9e6a03;
 }
 
-.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+.markdown-alert.markdown-alert-warning .markdown-alert-title {
   color: #d29922;
 }
 
-.markdown-body .markdown-alert.markdown-alert-tip {
+.markdown-alert.markdown-alert-tip {
   border-left-color: #238636;
 }
 
-.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+.markdown-alert.markdown-alert-tip .markdown-alert-title {
   color: #3fb950;
 }
 
-.markdown-body .markdown-alert.markdown-alert-caution {
+.markdown-alert.markdown-alert-caution {
   border-left-color: #da3633;
 }
 
-.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+.markdown-alert.markdown-alert-caution .markdown-alert-title {
   color: #f85149;
 }
 

--- a/inst/rmarkdown/templates/reprex_document/resources/github-light.css
+++ b/inst/rmarkdown/templates/reprex_document/resources/github-light.css
@@ -1,0 +1,1102 @@
+/*light*/
+
+.markdown-body {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  color: #1f2328;
+  background-color: #ffffff;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+  scroll-behavior: auto;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  fill: currentColor;
+  vertical-align: text-bottom;
+}
+
+.markdown-body h1:hover .anchor .octicon-link:before,
+.markdown-body h2:hover .anchor .octicon-link:before,
+.markdown-body h3:hover .anchor .octicon-link:before,
+.markdown-body h4:hover .anchor .octicon-link:before,
+.markdown-body h5:hover .anchor .octicon-link:before,
+.markdown-body h6:hover .anchor .octicon-link:before {
+  width: 16px;
+  height: 16px;
+  content: ' ';
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: transparent;
+  color: #0969da;
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: 600;
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: 1px solid #d0d7deb3;
+}
+
+.markdown-body mark {
+  background-color: #fff8c5;
+  color: #1f2328;
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: #ffffff;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: monospace;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em 40px;
+}
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid #d0d7deb3;
+  height: .25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: #d0d7de;
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  -webkit-appearance: button;
+  appearance: button;
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body [type=number]::-webkit-inner-spin-button,
+.markdown-body [type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type=search]::-webkit-search-cancel-button,
+.markdown-body [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+
+.markdown-body ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body ::placeholder {
+  color: #636c76;
+  opacity: 1;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body details:not([open])>*:not(summary) {
+  display: none;
+}
+
+.markdown-body a:focus,
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
+  outline: 2px solid #0969da;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+  outline: solid 1px transparent;
+}
+
+.markdown-body a:focus-visible,
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:not([class]):focus,
+.markdown-body a:not([class]):focus-visible,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline-offset: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  line-height: 10px;
+  color: #1f2328;
+  vertical-align: middle;
+  background-color: #f6f8fa;
+  border: solid 1px #afb8c133;
+  border-bottom-color: #afb8c133;
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 #afb8c133;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid #d0d7deb3;
+}
+
+.markdown-body h3 {
+  font-weight: 600;
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: 600;
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: 600;
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: 600;
+  font-size: .85em;
+  color: #636c76;
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #636c76;
+  border-left: .25em solid #d0d7de;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  word-wrap: normal;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body input::-webkit-outer-spin-button,
+.markdown-body input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body .mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: #d1242f;
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  outline: none;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: #1f2328;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: 16px;
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+.markdown-body dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.markdown-body table th {
+  font-weight: 600;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #d0d7de;
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: #ffffff;
+  border-top: 1px solid #d0d7deb3;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+.markdown-body table img {
+  background-color: transparent;
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: transparent;
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid #d0d7de;
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: #1f2328;
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: #afb8c133;
+  border-radius: 6px;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: 16px;
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: #1f2328;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px 8px 9px;
+  text-align: right;
+  background: #ffffff;
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: 600;
+  background: #f6f8fa;
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: #636c76;
+  border-top: 1px solid #d0d7de;
+}
+
+.markdown-body .footnotes ol {
+  padding-left: 16px;
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: 16px;
+  margin-top: 16px;
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .footnotes li:target::before {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  left: -24px;
+  pointer-events: none;
+  content: "";
+  border: 2px solid #0969da;
+  border-radius: 6px;
+}
+
+.markdown-body .footnotes li:target {
+  color: #1f2328;
+}
+
+.markdown-body .footnotes .data-footnote-backref g-emoji {
+  font-family: monospace;
+}
+
+.markdown-body .pl-c {
+  color: #57606a;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: #0550ae;
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: #6639ba;
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: #24292f;
+}
+
+.markdown-body .pl-ent {
+  color: #0550ae;
+}
+
+.markdown-body .pl-k {
+  color: #cf222e;
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: #0a3069;
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: #953800;
+}
+
+.markdown-body .pl-bu {
+  color: #82071e;
+}
+
+.markdown-body .pl-ii {
+  color: #f6f8fa;
+  background-color: #82071e;
+}
+
+.markdown-body .pl-c2 {
+  color: #f6f8fa;
+  background-color: #cf222e;
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: #116329;
+}
+
+.markdown-body .pl-ml {
+  color: #3b2300;
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: #0550ae;
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: #24292f;
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: #24292f;
+}
+
+.markdown-body .pl-md {
+  color: #82071e;
+  background-color: #ffebe9;
+}
+
+.markdown-body .pl-mi1 {
+  color: #116329;
+  background-color: #dafbe1;
+}
+
+.markdown-body .pl-mc {
+  color: #953800;
+  background-color: #ffd8b5;
+}
+
+.markdown-body .pl-mi2 {
+  color: #eaeef2;
+  background-color: #0550ae;
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: #8250df;
+}
+
+.markdown-body .pl-ba {
+  color: #57606a;
+}
+
+.markdown-body .pl-sg {
+  color: #8c959f;
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: #0a3069;
+}
+
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  min-width: 1ch;
+  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: 400;
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: 400;
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: 0.25rem;
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body .contains-task-list:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body .contains-task-list {
+  position: relative;
+}
+
+.markdown-body .contains-task-list:hover .task-list-item-convert-container,
+.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip: auto;
+}
+
+.markdown-body ::-webkit-calendar-picker-indicator {
+  filter: invert(50%);
+}
+
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  color: inherit;
+  border-left: .25em solid #d0d7de;
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  font-weight: 500;
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: #bf8700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: #9a6700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: #cf222e;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: #d1242f;
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}

--- a/inst/rmarkdown/templates/reprex_document/resources/github-light.css
+++ b/inst/rmarkdown/templates/reprex_document/resources/github-light.css
@@ -1,6 +1,6 @@
 /*light*/
 
-.markdown-body {
+body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0;
@@ -13,18 +13,28 @@
   scroll-behavior: auto;
 }
 
-.markdown-body .octicon {
+/* reprex tweaks */
+body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+  padding-top: 15px;
+}
+
+.octicon {
   display: inline-block;
   fill: currentColor;
   vertical-align: text-bottom;
 }
 
-.markdown-body h1:hover .anchor .octicon-link:before,
-.markdown-body h2:hover .anchor .octicon-link:before,
-.markdown-body h3:hover .anchor .octicon-link:before,
-.markdown-body h4:hover .anchor .octicon-link:before,
-.markdown-body h5:hover .anchor .octicon-link:before,
-.markdown-body h6:hover .anchor .octicon-link:before {
+h1:hover .anchor .octicon-link:before,
+h2:hover .anchor .octicon-link:before,
+h3:hover .anchor .octicon-link:before,
+h4:hover .anchor .octicon-link:before,
+h5:hover .anchor .octicon-link:before,
+h6:hover .anchor .octicon-link:before {
   width: 16px;
   height: 16px;
   content: ' ';
@@ -34,42 +44,42 @@
   mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
 }
 
-.markdown-body details,
-.markdown-body figcaption,
-.markdown-body figure {
+details,
+figcaption,
+figure {
   display: block;
 }
 
-.markdown-body summary {
+summary {
   display: list-item;
 }
 
-.markdown-body [hidden] {
+[hidden] {
   display: none !important;
 }
 
-.markdown-body a {
+a {
   background-color: transparent;
   color: #0969da;
   text-decoration: none;
 }
 
-.markdown-body abbr[title] {
+abbr[title] {
   border-bottom: none;
   -webkit-text-decoration: underline dotted;
   text-decoration: underline dotted;
 }
 
-.markdown-body b,
-.markdown-body strong {
+b,
+strong {
   font-weight: 600;
 }
 
-.markdown-body dfn {
+dfn {
   font-style: italic;
 }
 
-.markdown-body h1 {
+h1 {
   margin: .67em 0;
   font-weight: 600;
   padding-bottom: .3em;
@@ -77,51 +87,51 @@
   border-bottom: 1px solid #d0d7deb3;
 }
 
-.markdown-body mark {
+mark {
   background-color: #fff8c5;
   color: #1f2328;
 }
 
-.markdown-body small {
+small {
   font-size: 90%;
 }
 
-.markdown-body sub,
-.markdown-body sup {
+sub,
+sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
   vertical-align: baseline;
 }
 
-.markdown-body sub {
+sub {
   bottom: -0.25em;
 }
 
-.markdown-body sup {
+sup {
   top: -0.5em;
 }
 
-.markdown-body img {
+img {
   border-style: none;
   max-width: 100%;
   box-sizing: content-box;
   background-color: #ffffff;
 }
 
-.markdown-body code,
-.markdown-body kbd,
-.markdown-body pre,
-.markdown-body samp {
+code,
+kbd,
+pre,
+samp {
   font-family: monospace;
   font-size: 1em;
 }
 
-.markdown-body figure {
+figure {
   margin: 1em 40px;
 }
 
-.markdown-body hr {
+hr {
   box-sizing: content-box;
   overflow: hidden;
   background: transparent;
@@ -133,7 +143,7 @@
   border: 0;
 }
 
-.markdown-body input {
+input {
   font: inherit;
   margin: 0;
   overflow: visible;
@@ -142,62 +152,62 @@
   line-height: inherit;
 }
 
-.markdown-body [type=button],
-.markdown-body [type=reset],
-.markdown-body [type=submit] {
+[type=button],
+[type=reset],
+[type=submit] {
   -webkit-appearance: button;
   appearance: button;
 }
 
-.markdown-body [type=checkbox],
-.markdown-body [type=radio] {
+[type=checkbox],
+[type=radio] {
   box-sizing: border-box;
   padding: 0;
 }
 
-.markdown-body [type=number]::-webkit-inner-spin-button,
-.markdown-body [type=number]::-webkit-outer-spin-button {
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
-.markdown-body [type=search]::-webkit-search-cancel-button,
-.markdown-body [type=search]::-webkit-search-decoration {
+[type=search]::-webkit-search-cancel-button,
+[type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }
 
-.markdown-body ::-webkit-input-placeholder {
+::-webkit-input-placeholder {
   color: inherit;
   opacity: .54;
 }
 
-.markdown-body ::-webkit-file-upload-button {
+::-webkit-file-upload-button {
   -webkit-appearance: button;
   appearance: button;
   font: inherit;
 }
 
-.markdown-body a:hover {
+a:hover {
   text-decoration: underline;
 }
 
-.markdown-body ::placeholder {
+::placeholder {
   color: #636c76;
   opacity: 1;
 }
 
-.markdown-body hr::before {
+hr::before {
   display: table;
   content: "";
 }
 
-.markdown-body hr::after {
+hr::after {
   display: table;
   clear: both;
   content: "";
 }
 
-.markdown-body table {
+table {
   border-spacing: 0;
   border-collapse: collapse;
   display: block;
@@ -206,54 +216,54 @@
   overflow: auto;
 }
 
-.markdown-body td,
-.markdown-body th {
+td,
+th {
   padding: 0;
 }
 
-.markdown-body details summary {
+details summary {
   cursor: pointer;
 }
 
-.markdown-body details:not([open])>*:not(summary) {
+details:not([open])>*:not(summary) {
   display: none;
 }
 
-.markdown-body a:focus,
-.markdown-body [role=button]:focus,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=checkbox]:focus {
+a:focus,
+[role=button]:focus,
+input[type=radio]:focus,
+input[type=checkbox]:focus {
   outline: 2px solid #0969da;
   outline-offset: -2px;
   box-shadow: none;
 }
 
-.markdown-body a:focus:not(:focus-visible),
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body input[type=radio]:focus:not(:focus-visible),
-.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+a:focus:not(:focus-visible),
+[role=button]:focus:not(:focus-visible),
+input[type=radio]:focus:not(:focus-visible),
+input[type=checkbox]:focus:not(:focus-visible) {
   outline: solid 1px transparent;
 }
 
-.markdown-body a:focus-visible,
-.markdown-body [role=button]:focus-visible,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus-visible {
+a:focus-visible,
+[role=button]:focus-visible,
+input[type=radio]:focus-visible,
+input[type=checkbox]:focus-visible {
   outline: 2px solid #0969da;
   outline-offset: -2px;
   box-shadow: none;
 }
 
-.markdown-body a:not([class]):focus,
-.markdown-body a:not([class]):focus-visible,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus,
-.markdown-body input[type=checkbox]:focus-visible {
+a:not([class]):focus,
+a:not([class]):focus-visible,
+input[type=radio]:focus,
+input[type=radio]:focus-visible,
+input[type=checkbox]:focus,
+input[type=checkbox]:focus-visible {
   outline-offset: 0;
 }
 
-.markdown-body kbd {
+kbd {
   display: inline-block;
   padding: 3px 5px;
   font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
@@ -267,89 +277,89 @@
   box-shadow: inset 0 -1px 0 #afb8c133;
 }
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin-top: 24px;
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
 }
 
-.markdown-body h2 {
+h2 {
   font-weight: 600;
   padding-bottom: .3em;
   font-size: 1.5em;
   border-bottom: 1px solid #d0d7deb3;
 }
 
-.markdown-body h3 {
+h3 {
   font-weight: 600;
   font-size: 1.25em;
 }
 
-.markdown-body h4 {
+h4 {
   font-weight: 600;
   font-size: 1em;
 }
 
-.markdown-body h5 {
+h5 {
   font-weight: 600;
   font-size: .875em;
 }
 
-.markdown-body h6 {
+h6 {
   font-weight: 600;
   font-size: .85em;
   color: #636c76;
 }
 
-.markdown-body p {
+p {
   margin-top: 0;
   margin-bottom: 10px;
 }
 
-.markdown-body blockquote {
+blockquote {
   margin: 0;
   padding: 0 1em;
   color: #636c76;
   border-left: .25em solid #d0d7de;
 }
 
-.markdown-body ul,
-.markdown-body ol {
+ul,
+ol {
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;
 }
 
-.markdown-body ol ol,
-.markdown-body ul ol {
+ol ol,
+ul ol {
   list-style-type: lower-roman;
 }
 
-.markdown-body ul ul ol,
-.markdown-body ul ol ol,
-.markdown-body ol ul ol,
-.markdown-body ol ol ol {
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
   list-style-type: lower-alpha;
 }
 
-.markdown-body dd {
+dd {
   margin-left: 0;
 }
 
-.markdown-body tt,
-.markdown-body code,
-.markdown-body samp {
+tt,
+code,
+samp {
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   font-size: 12px;
 }
 
-.markdown-body pre {
+pre {
   margin-top: 0;
   margin-bottom: 0;
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
@@ -357,21 +367,21 @@
   word-wrap: normal;
 }
 
-.markdown-body .octicon {
+.octicon {
   display: inline-block;
   overflow: visible !important;
   vertical-align: text-bottom;
   fill: currentColor;
 }
 
-.markdown-body input::-webkit-outer-spin-button,
-.markdown-body input::-webkit-inner-spin-button {
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   appearance: none;
 }
 
-.markdown-body .mr-2 {
+.mr-2 {
   margin-right: 0.5rem !important;
 }
 
@@ -394,166 +404,166 @@
   margin-bottom: 0 !important;
 }
 
-.markdown-body a:not([href]) {
+a:not([href]) {
   color: inherit;
   text-decoration: none;
 }
 
-.markdown-body .absent {
+.absent {
   color: #d1242f;
 }
 
-.markdown-body .anchor {
+.anchor {
   float: left;
   padding-right: 4px;
   margin-left: -20px;
   line-height: 1;
 }
 
-.markdown-body .anchor:focus {
+.anchor:focus {
   outline: none;
 }
 
-.markdown-body p,
-.markdown-body blockquote,
-.markdown-body ul,
-.markdown-body ol,
-.markdown-body dl,
-.markdown-body table,
-.markdown-body pre,
-.markdown-body details {
+p,
+blockquote,
+ul,
+ol,
+dl,
+table,
+pre,
+details {
   margin-top: 0;
   margin-bottom: 16px;
 }
 
-.markdown-body blockquote>:first-child {
+blockquote>:first-child {
   margin-top: 0;
 }
 
-.markdown-body blockquote>:last-child {
+blockquote>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
+h1 .octicon-link,
+h2 .octicon-link,
+h3 .octicon-link,
+h4 .octicon-link,
+h5 .octicon-link,
+h6 .octicon-link {
   color: #1f2328;
   vertical-align: middle;
   visibility: hidden;
 }
 
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
   text-decoration: none;
 }
 
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
+h1:hover .anchor .octicon-link,
+h2:hover .anchor .octicon-link,
+h3:hover .anchor .octicon-link,
+h4:hover .anchor .octicon-link,
+h5:hover .anchor .octicon-link,
+h6:hover .anchor .octicon-link {
   visibility: visible;
 }
 
-.markdown-body h1 tt,
-.markdown-body h1 code,
-.markdown-body h2 tt,
-.markdown-body h2 code,
-.markdown-body h3 tt,
-.markdown-body h3 code,
-.markdown-body h4 tt,
-.markdown-body h4 code,
-.markdown-body h5 tt,
-.markdown-body h5 code,
-.markdown-body h6 tt,
-.markdown-body h6 code {
+h1 tt,
+h1 code,
+h2 tt,
+h2 code,
+h3 tt,
+h3 code,
+h4 tt,
+h4 code,
+h5 tt,
+h5 code,
+h6 tt,
+h6 code {
   padding: 0 .2em;
   font-size: inherit;
 }
 
-.markdown-body summary h1,
-.markdown-body summary h2,
-.markdown-body summary h3,
-.markdown-body summary h4,
-.markdown-body summary h5,
-.markdown-body summary h6 {
+summary h1,
+summary h2,
+summary h3,
+summary h4,
+summary h5,
+summary h6 {
   display: inline-block;
 }
 
-.markdown-body summary h1 .anchor,
-.markdown-body summary h2 .anchor,
-.markdown-body summary h3 .anchor,
-.markdown-body summary h4 .anchor,
-.markdown-body summary h5 .anchor,
-.markdown-body summary h6 .anchor {
+summary h1 .anchor,
+summary h2 .anchor,
+summary h3 .anchor,
+summary h4 .anchor,
+summary h5 .anchor,
+summary h6 .anchor {
   margin-left: -40px;
 }
 
-.markdown-body summary h1,
-.markdown-body summary h2 {
+summary h1,
+summary h2 {
   padding-bottom: 0;
   border-bottom: 0;
 }
 
-.markdown-body ul.no-list,
-.markdown-body ol.no-list {
+ul.no-list,
+ol.no-list {
   padding: 0;
   list-style-type: none;
 }
 
-.markdown-body ol[type="a s"] {
+ol[type="a s"] {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type="A s"] {
+ol[type="A s"] {
   list-style-type: upper-alpha;
 }
 
-.markdown-body ol[type="i s"] {
+ol[type="i s"] {
   list-style-type: lower-roman;
 }
 
-.markdown-body ol[type="I s"] {
+ol[type="I s"] {
   list-style-type: upper-roman;
 }
 
-.markdown-body ol[type="1"] {
+ol[type="1"] {
   list-style-type: decimal;
 }
 
-.markdown-body div>ol:not([type]) {
+div>ol:not([type]) {
   list-style-type: decimal;
 }
 
-.markdown-body ul ul,
-.markdown-body ul ol,
-.markdown-body ol ol,
-.markdown-body ol ul {
+ul ul,
+ul ol,
+ol ol,
+ol ul {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.markdown-body li>p {
+li>p {
   margin-top: 16px;
 }
 
-.markdown-body li+li {
+li+li {
   margin-top: .25em;
 }
 
-.markdown-body dl {
+dl {
   padding: 0;
 }
 
-.markdown-body dl dt {
+dl dt {
   padding: 0;
   margin-top: 16px;
   font-size: 1em;
@@ -561,58 +571,58 @@
   font-weight: 600;
 }
 
-.markdown-body dl dd {
+dl dd {
   padding: 0 16px;
   margin-bottom: 16px;
 }
 
-.markdown-body table th {
+table th {
   font-weight: 600;
 }
 
-.markdown-body table th,
-.markdown-body table td {
+table th,
+table td {
   padding: 6px 13px;
   border: 1px solid #d0d7de;
 }
 
-.markdown-body table td>:last-child {
+table td>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body table tr {
+table tr {
   background-color: #ffffff;
   border-top: 1px solid #d0d7deb3;
 }
 
-.markdown-body table tr:nth-child(2n) {
+table tr:nth-child(2n) {
   background-color: #f6f8fa;
 }
 
-.markdown-body table img {
+table img {
   background-color: transparent;
 }
 
-.markdown-body img[align=right] {
+img[align=right] {
   padding-left: 20px;
 }
 
-.markdown-body img[align=left] {
+img[align=left] {
   padding-right: 20px;
 }
 
-.markdown-body .emoji {
+.emoji {
   max-width: none;
   vertical-align: text-top;
   background-color: transparent;
 }
 
-.markdown-body span.frame {
+span.frame {
   display: block;
   overflow: hidden;
 }
 
-.markdown-body span.frame>span {
+span.frame>span {
   display: block;
   float: left;
   width: auto;
@@ -622,81 +632,81 @@
   border: 1px solid #d0d7de;
 }
 
-.markdown-body span.frame span img {
+span.frame span img {
   display: block;
   float: left;
 }
 
-.markdown-body span.frame span span {
+span.frame span span {
   display: block;
   padding: 5px 0 0;
   clear: both;
   color: #1f2328;
 }
 
-.markdown-body span.align-center {
+span.align-center {
   display: block;
   overflow: hidden;
   clear: both;
 }
 
-.markdown-body span.align-center>span {
+span.align-center>span {
   display: block;
   margin: 13px auto 0;
   overflow: hidden;
   text-align: center;
 }
 
-.markdown-body span.align-center span img {
+span.align-center span img {
   margin: 0 auto;
   text-align: center;
 }
 
-.markdown-body span.align-right {
+span.align-right {
   display: block;
   overflow: hidden;
   clear: both;
 }
 
-.markdown-body span.align-right>span {
+span.align-right>span {
   display: block;
   margin: 13px 0 0;
   overflow: hidden;
   text-align: right;
 }
 
-.markdown-body span.align-right span img {
+span.align-right span img {
   margin: 0;
   text-align: right;
 }
 
-.markdown-body span.float-left {
+span.float-left {
   display: block;
   float: left;
   margin-right: 13px;
   overflow: hidden;
 }
 
-.markdown-body span.float-left span {
+span.float-left span {
   margin: 13px 0 0;
 }
 
-.markdown-body span.float-right {
+span.float-right {
   display: block;
   float: right;
   margin-left: 13px;
   overflow: hidden;
 }
 
-.markdown-body span.float-right>span {
+span.float-right>span {
   display: block;
   margin: 13px auto 0;
   overflow: hidden;
   text-align: right;
 }
 
-.markdown-body code,
-.markdown-body tt {
+code,
+tt {
   padding: .2em .4em;
   margin: 0;
   font-size: 85%;
@@ -705,24 +715,24 @@
   border-radius: 6px;
 }
 
-.markdown-body code br,
-.markdown-body tt br {
+code br,
+tt br {
   display: none;
 }
 
-.markdown-body del code {
+del code {
   text-decoration: inherit;
 }
 
-.markdown-body samp {
+samp {
   font-size: 85%;
 }
 
-.markdown-body pre code {
+pre code {
   font-size: 100%;
 }
 
-.markdown-body pre>code {
+pre>code {
   padding: 0;
   margin: 0;
   word-break: normal;
@@ -731,17 +741,17 @@
   border: 0;
 }
 
-.markdown-body .highlight {
+.highlight {
   margin-bottom: 16px;
 }
 
-.markdown-body .highlight pre {
+.highlight pre {
   margin-bottom: 0;
   word-break: normal;
 }
 
-.markdown-body .highlight pre,
-.markdown-body pre {
+.highlight pre,
+pre {
   padding: 16px;
   overflow: auto;
   font-size: 85%;
@@ -751,8 +761,8 @@
   border-radius: 6px;
 }
 
-.markdown-body pre code,
-.markdown-body pre tt {
+pre code,
+pre tt {
   display: inline;
   max-width: auto;
   padding: 0;
@@ -764,8 +774,8 @@
   border: 0;
 }
 
-.markdown-body .csv-data td,
-.markdown-body .csv-data th {
+.csv-data td,
+.csv-data th {
   padding: 5px;
   overflow: hidden;
   font-size: 12px;
@@ -774,52 +784,52 @@
   white-space: nowrap;
 }
 
-.markdown-body .csv-data .blob-num {
+.csv-data .blob-num {
   padding: 10px 8px 9px;
   text-align: right;
   background: #ffffff;
   border: 0;
 }
 
-.markdown-body .csv-data tr {
+.csv-data tr {
   border-top: 0;
 }
 
-.markdown-body .csv-data th {
+.csv-data th {
   font-weight: 600;
   background: #f6f8fa;
   border-top: 0;
 }
 
-.markdown-body [data-footnote-ref]::before {
+[data-footnote-ref]::before {
   content: "[";
 }
 
-.markdown-body [data-footnote-ref]::after {
+[data-footnote-ref]::after {
   content: "]";
 }
 
-.markdown-body .footnotes {
+.footnotes {
   font-size: 12px;
   color: #636c76;
   border-top: 1px solid #d0d7de;
 }
 
-.markdown-body .footnotes ol {
+.footnotes ol {
   padding-left: 16px;
 }
 
-.markdown-body .footnotes ol ul {
+.footnotes ol ul {
   display: inline-block;
   padding-left: 16px;
   margin-top: 16px;
 }
 
-.markdown-body .footnotes li {
+.footnotes li {
   position: relative;
 }
 
-.markdown-body .footnotes li:target::before {
+.footnotes li:target::before {
   position: absolute;
   top: -8px;
   right: -8px;
@@ -831,149 +841,149 @@
   border-radius: 6px;
 }
 
-.markdown-body .footnotes li:target {
+.footnotes li:target {
   color: #1f2328;
 }
 
-.markdown-body .footnotes .data-footnote-backref g-emoji {
+.footnotes .data-footnote-backref g-emoji {
   font-family: monospace;
 }
 
-.markdown-body .pl-c {
+.pl-c {
   color: #57606a;
 }
 
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
+.pl-c1,
+.pl-s .pl-v {
   color: #0550ae;
 }
 
-.markdown-body .pl-e,
-.markdown-body .pl-en {
+.pl-e,
+.pl-en {
   color: #6639ba;
 }
 
-.markdown-body .pl-smi,
-.markdown-body .pl-s .pl-s1 {
+.pl-smi,
+.pl-s .pl-s1 {
   color: #24292f;
 }
 
-.markdown-body .pl-ent {
+.pl-ent {
   color: #0550ae;
 }
 
-.markdown-body .pl-k {
+.pl-k {
   color: #cf222e;
 }
 
-.markdown-body .pl-s,
-.markdown-body .pl-pds,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sre,
-.markdown-body .pl-sr .pl-sra {
+.pl-s,
+.pl-pds,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sre,
+.pl-sr .pl-sra {
   color: #0a3069;
 }
 
-.markdown-body .pl-v,
-.markdown-body .pl-smw {
+.pl-v,
+.pl-smw {
   color: #953800;
 }
 
-.markdown-body .pl-bu {
+.pl-bu {
   color: #82071e;
 }
 
-.markdown-body .pl-ii {
+.pl-ii {
   color: #f6f8fa;
   background-color: #82071e;
 }
 
-.markdown-body .pl-c2 {
+.pl-c2 {
   color: #f6f8fa;
   background-color: #cf222e;
 }
 
-.markdown-body .pl-sr .pl-cce {
+.pl-sr .pl-cce {
   font-weight: bold;
   color: #116329;
 }
 
-.markdown-body .pl-ml {
+.pl-ml {
   color: #3b2300;
 }
 
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
   font-weight: bold;
   color: #0550ae;
 }
 
-.markdown-body .pl-mi {
+.pl-mi {
   font-style: italic;
   color: #24292f;
 }
 
-.markdown-body .pl-mb {
+.pl-mb {
   font-weight: bold;
   color: #24292f;
 }
 
-.markdown-body .pl-md {
+.pl-md {
   color: #82071e;
   background-color: #ffebe9;
 }
 
-.markdown-body .pl-mi1 {
+.pl-mi1 {
   color: #116329;
   background-color: #dafbe1;
 }
 
-.markdown-body .pl-mc {
+.pl-mc {
   color: #953800;
   background-color: #ffd8b5;
 }
 
-.markdown-body .pl-mi2 {
+.pl-mi2 {
   color: #eaeef2;
   background-color: #0550ae;
 }
 
-.markdown-body .pl-mdr {
+.pl-mdr {
   font-weight: bold;
   color: #8250df;
 }
 
-.markdown-body .pl-ba {
+.pl-ba {
   color: #57606a;
 }
 
-.markdown-body .pl-sg {
+.pl-sg {
   color: #8c959f;
 }
 
-.markdown-body .pl-corl {
+.pl-corl {
   text-decoration: underline;
   color: #0a3069;
 }
 
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
-.markdown-body button:focus:not(:focus-visible),
-.markdown-body summary:focus:not(:focus-visible),
-.markdown-body a:focus:not(:focus-visible) {
+[role=button]:focus:not(:focus-visible),
+[role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+button:focus:not(:focus-visible),
+summary:focus:not(:focus-visible),
+a:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.markdown-body [tabindex="0"]:focus:not(:focus-visible),
-.markdown-body details-dialog:focus:not(:focus-visible) {
+[tabindex="0"]:focus:not(:focus-visible),
+details-dialog:focus:not(:focus-visible) {
   outline: none;
 }
 
-.markdown-body g-emoji {
+g-emoji {
   display: inline-block;
   min-width: 1ch;
   font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -984,46 +994,46 @@
   vertical-align: -0.075em;
 }
 
-.markdown-body g-emoji img {
+g-emoji img {
   width: 1em;
   height: 1em;
 }
 
-.markdown-body .task-list-item {
+.task-list-item {
   list-style-type: none;
 }
 
-.markdown-body .task-list-item label {
+.task-list-item label {
   font-weight: 400;
 }
 
-.markdown-body .task-list-item.enabled label {
+.task-list-item.enabled label {
   cursor: pointer;
 }
 
-.markdown-body .task-list-item+.task-list-item {
+.task-list-item+.task-list-item {
   margin-top: 0.25rem;
 }
 
-.markdown-body .task-list-item .handle {
+.task-list-item .handle {
   display: none;
 }
 
-.markdown-body .task-list-item-checkbox {
+.task-list-item-checkbox {
   margin: 0 .2em .25em -1.4em;
   vertical-align: middle;
 }
 
-.markdown-body .contains-task-list:dir(rtl) .task-list-item-checkbox {
+.contains-task-list:dir(rtl) .task-list-item-checkbox {
   margin: 0 -1.6em .25em .2em;
 }
 
-.markdown-body .contains-task-list {
+.contains-task-list {
   position: relative;
 }
 
-.markdown-body .contains-task-list:hover .task-list-item-convert-container,
-.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+.contains-task-list:hover .task-list-item-convert-container,
+.contains-task-list:focus-within .task-list-item-convert-container {
   display: block;
   width: auto;
   height: 24px;
@@ -1031,69 +1041,69 @@
   clip: auto;
 }
 
-.markdown-body ::-webkit-calendar-picker-indicator {
+::-webkit-calendar-picker-indicator {
   filter: invert(50%);
 }
 
-.markdown-body .markdown-alert {
+.markdown-alert {
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
   color: inherit;
   border-left: .25em solid #d0d7de;
 }
 
-.markdown-body .markdown-alert>:first-child {
+.markdown-alert>:first-child {
   margin-top: 0;
 }
 
-.markdown-body .markdown-alert>:last-child {
+.markdown-alert>:last-child {
   margin-bottom: 0;
 }
 
-.markdown-body .markdown-alert .markdown-alert-title {
+.markdown-alert .markdown-alert-title {
   display: flex;
   font-weight: 500;
   align-items: center;
   line-height: 1;
 }
 
-.markdown-body .markdown-alert.markdown-alert-note {
+.markdown-alert.markdown-alert-note {
   border-left-color: #0969da;
 }
 
-.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+.markdown-alert.markdown-alert-note .markdown-alert-title {
   color: #0969da;
 }
 
-.markdown-body .markdown-alert.markdown-alert-important {
+.markdown-alert.markdown-alert-important {
   border-left-color: #8250df;
 }
 
-.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+.markdown-alert.markdown-alert-important .markdown-alert-title {
   color: #8250df;
 }
 
-.markdown-body .markdown-alert.markdown-alert-warning {
+.markdown-alert.markdown-alert-warning {
   border-left-color: #bf8700;
 }
 
-.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+.markdown-alert.markdown-alert-warning .markdown-alert-title {
   color: #9a6700;
 }
 
-.markdown-body .markdown-alert.markdown-alert-tip {
+.markdown-alert.markdown-alert-tip {
   border-left-color: #1a7f37;
 }
 
-.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+.markdown-alert.markdown-alert-tip .markdown-alert-title {
   color: #1a7f37;
 }
 
-.markdown-body .markdown-alert.markdown-alert-caution {
+.markdown-alert.markdown-alert-caution {
   border-left-color: #cf222e;
 }
 
-.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+.markdown-alert.markdown-alert-caution .markdown-alert-title {
   color: #d1242f;
 }
 

--- a/inst/rmarkdown/templates/reprex_document/resources/r.xml
+++ b/inst/rmarkdown/templates/reprex_document/resources/r.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language>
+<!-- Kate 2.5 (KDE 3.5) highlighting module for R
+	based on an earlier version by E.L. Willighagen. Code folding code by Ben Goodrich
+	version 2.0: (c) 2006 Thomas Friedrichsmeier, Arne Henningsen, and the RKWard Team
+	license: GPL v2
+	Kate   : http://kate.kde.org/
+	R      : http://www.r-project.org/
+	RKWard : http://rkward.kde.org/
+	-->
+<language version="14" kateversion="5.0" name="R Script" section="Scientific" extensions="*.R;*.r;*.S;*.s;*.q" mimetype="" license="GPLv2">
+<highlighting>
+
+	<list name="controls">
+		<item>for</item>
+		<item>in</item>
+		<item>next</item>
+		<item>break</item>
+		<item>while</item>
+		<item>repeat</item>
+		<item>if</item>
+		<item>else</item>
+		<item>switch</item>
+		<item>function</item>
+	</list>
+	<list name="words">
+		<item>TRUE</item>
+		<item>FALSE</item>
+		<item>NULL</item>
+		<item>NA</item>
+		<item>NA_integer_</item>
+		<item>NA_real_</item>
+		<item>NA_complex_</item>
+		<item>NA_character_</item>
+		<item>Inf</item>
+		<item>NaN</item>
+	</list>
+
+	<contexts>
+		<!-- This context is really only good for detecting unexpected closing braces '}'. Since opening braces go to ctx0 (and nesting in there), this context is only active on the base level -->
+		<context attribute="Normal Text" lineEndContext="#stay" name="level0">
+			<IncludeRules context="CommonRules"/>
+
+			<AnyChar attribute="Error" context="#stay" String="})"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="ctx0">
+			<IncludeRules context="CommonRules"/>
+
+			<DetectChar attribute="Symbol" context="#pop" char="}" endRegion="Brace1" />
+			<DetectChar attribute="Error" context="#stay" char=")"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="parenthesis">
+			<LineContinue attribute="Operator" context="#stay"/>
+			<DetectChar attribute="Symbol" context="#pop" char=")"/>
+
+			<RegExpr attribute="Identifier" context="#stay" String="[a-zA-Z_\.][0-9a-zA-Z_\.]*[\s]*[:]?=(?=[^=]|$)"/>
+
+			<IncludeRules context="CommonRules"/>
+			<DetectChar attribute="Error" context="#stay" char="}" />
+		</context>
+
+		<context attribute="String" lineEndContext="#stay" name="string">
+			<DetectChar attribute="String" context="#pop" char="&quot;"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="String" lineEndContext="#stay" name="string2">
+			<DetectChar attribute="String" context="#pop" char="'"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="Identifier" lineEndContext="#stay" name="backquotedsymbol">
+			<DetectChar attribute="String" context="#pop" char="`"/>
+			<HlCStringChar attribute="String Char" context="#stay"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="operator_rhs" fallthrough="true" fallthroughContext="#pop">
+			<!-- While there is nothing of interest, stay in the context -->
+			<DetectSpaces />
+			<IncludeRules context="FindComments"/>
+			<!-- Operators other than +, -, and ! directly after another operator are an error. -->
+			<Detect2Chars attribute="Error" context="#stay" char="!" char1="="/>
+			<AnyChar attribute="Error" context="#stay" String="*/&lt;&gt;=|&amp;:^@$~"/>
+		</context>
+
+		<context attribute="Numeric Suffix" lineEndContext="#pop" name="NumericSuffix" fallthrough="true" fallthroughContext="#pop">
+			<AnyChar attribute="Numeric Suffix" context="#pop" String="Li"/>
+		</context>
+
+		<context attribute="Normal Text" lineEndContext="#stay" name="FindComments">
+			<Detect2Chars attribute="Headline" context="Headline" char="#" char1="#"/>
+			<DetectChar attribute="Comment" context="Comment" char="#"/>
+		</context>
+		<context attribute="Headline" lineEndContext="#pop" name="Headline">
+			<DetectSpaces />
+			<IncludeRules context="##Comments" />
+		</context>
+		<context attribute="Comment" lineEndContext="#pop" name="Comment">
+			<DetectSpaces />
+			<IncludeRules context="##Comments" />
+		</context>
+
+		<!-- This context is not really used, but contains the common rules -->
+		<context name="CommonRules" lineEndContext="#stay" attribute="Normal Text" >
+			<DetectSpaces />
+			<IncludeRules context="FindComments"/>
+			<DetectChar attribute="String" context="string" char="&quot;"/>
+			<DetectChar attribute="String" context="string2" char="'"/>
+			<DetectChar attribute="String" context="backquotedsymbol" char="`"/>
+			<keyword attribute="Control Structure" context="#stay" String="controls"/>
+			<keyword attribute="Reserved Words" context="#stay" String="words"/>
+			<Float attribute="Float" context="#stay"/>
+			<Int attribute="Int" context="NumericSuffix"/>
+			<RegExpr attribute="Keyword" context="#stay" String="[a-zA-Z_]+[a-zA-Z_\.0-9]*(?=[\s]*[(])|\.[a-zA-Z_\.]+[a-zA-Z_\.0-9]*(?=[\s]*[(])"/>
+			<DetectChar attribute="Symbol" context="parenthesis" char="("/>
+
+			<!-- For (assignment) operators, enter a new context operator_rhs to check what follows (generally, that should not be another op) -->
+			<StringDetect attribute="Assign" context="operator_rhs" String="&lt;&lt;-"/>
+			<Detect2Chars attribute="Assign" context="operator_rhs" char="&lt;" char1="-"/>
+			<StringDetect attribute="Assign" context="operator_rhs" String="-&gt;&gt;"/>
+			<Detect2Chars attribute="Assign" context="operator_rhs" char="-" char1="&gt;"/>
+			<RegExpr attribute="Assign" context="operator_rhs" String="=(?!(=|&gt;))"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="*" char1="*"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&lt;" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&gt;" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="=" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="=" char1="&gt;"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="!" char1="="/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="|" char1="&gt;"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="|" char1="|"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char="&amp;" char1="&amp;"/>
+			<StringDetect attribute="Operator" context="operator_rhs" String=":::"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char=":" char1=":"/>
+			<Detect2Chars attribute="Operator" context="operator_rhs" char=":" char1="="/>
+			<AnyChar attribute="Operator" context="operator_rhs" String="+-*/&lt;&gt;=!|&amp;:^@$~"/>
+			<RangeDetect attribute="Operator" context="operator_rhs" char="%" char1="%"/>
+
+			<DetectChar attribute="Symbol" context="ctx0" char="{" beginRegion="Brace1" />
+
+			<!-- This is needed only to assist variable based indentation -->
+			<AnyChar attribute="Symbol" context="#stay" String="[]" />
+		</context>
+	</contexts>
+
+	<itemDatas>
+		<itemData name="Normal Text" defStyleNum="dsNormal" spellChecking="false"/>
+		<itemData name="Symbol" defStyleNum="dsNormal" spellChecking="false"/>
+		<itemData name="Keyword" defStyleNum="dsFunction" spellChecking="false"/>
+		<itemData name="Identifier" defStyleNum="dsAttribute" spellChecking="false"/>
+		<itemData name="String" defStyleNum="dsString"/>
+		<itemData name="Headline" defStyleNum="dsDocumentation" bold="1"/>
+		<itemData name="Comment" defStyleNum="dsComment"/>
+		<itemData name="Assign" defStyleNum="dsOthers" bold="1" italic="0" spellChecking="false"/>
+		<itemData name="Control Structure" defStyleNum="dsControlFlow" spellChecking="false"/>
+		<itemData name="Reserved Words" defStyleNum="dsConstant" spellChecking="false"/>
+		<itemData name="Error" defStyleNum="dsError" spellChecking="false"/>
+		<itemData name="Operator" defStyleNum="dsSpecialChar" spellChecking="false"/>
+		<itemData name="String Char"  defStyleNum="dsSpecialChar" spellChecking="false"/>
+		<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
+		<itemData name="Int" defStyleNum="dsDecVal" spellChecking="false"/>
+		<itemData name="Numeric Suffix" defStyleNum="dsDataType" spellChecking="false"/>
+	</itemDatas>
+</highlighting>
+
+<general>
+	<comments>
+		<comment name="singleLine" start="#"/>
+	</comments>
+	<keywords casesensitive="true" weakDeliminator="." additionalDeliminator="$"/>
+</general>
+</language>
+<!-- kate: replace-tabs off; -->

--- a/inst/rmarkdown/templates/reprex_document/resources/r.xml
+++ b/inst/rmarkdown/templates/reprex_document/resources/r.xml
@@ -113,7 +113,7 @@
 			<keyword attribute="Reserved Words" context="#stay" String="words"/>
 			<Float attribute="Float" context="#stay"/>
 			<Int attribute="Int" context="NumericSuffix"/>
-			<RegExpr attribute="Keyword" context="#stay" String="[a-zA-Z_]+[a-zA-Z_\.0-9]*(?=[\s]*[(])|\.[a-zA-Z_\.]+[a-zA-Z_\.0-9]*(?=[\s]*[(])"/>
+			<RegExpr attribute="Function" context="#stay" String="[a-zA-Z_]+[a-zA-Z_\.0-9]*(?=[\s]*[(])|\.[a-zA-Z_\.]+[a-zA-Z_\.0-9]*(?=[\s]*[(])"/>
 			<DetectChar attribute="Symbol" context="parenthesis" char="("/>
 
 			<!-- For (assignment) operators, enter a new context operator_rhs to check what follows (generally, that should not be another op) -->
@@ -146,18 +146,19 @@
 
 	<itemDatas>
 		<itemData name="Normal Text" defStyleNum="dsNormal" spellChecking="false"/>
-		<itemData name="Symbol" defStyleNum="dsNormal" spellChecking="false"/>
-		<itemData name="Keyword" defStyleNum="dsFunction" spellChecking="false"/>
-		<itemData name="Identifier" defStyleNum="dsAttribute" spellChecking="false"/>
+		<itemData name="Symbol" defStyleNum="dsVariable" spellChecking="false"/>
+		<itemData name="Keyword" defStyleNum="dsKeyword" spellChecking="false"/>
+		<itemData name="Function" defStyleNum="dsFunction" spellChecking="false"/>
+		<itemData name="Identifier" defStyleNum="dsVariable" spellChecking="false"/>
 		<itemData name="String" defStyleNum="dsString"/>
 		<itemData name="Headline" defStyleNum="dsDocumentation" bold="1"/>
 		<itemData name="Comment" defStyleNum="dsComment"/>
-		<itemData name="Assign" defStyleNum="dsOthers" bold="1" italic="0" spellChecking="false"/>
+		<itemData name="Assign" defStyleNum="dsOperator" bold="1" italic="0" spellChecking="false"/>
 		<itemData name="Control Structure" defStyleNum="dsControlFlow" spellChecking="false"/>
-		<itemData name="Reserved Words" defStyleNum="dsConstant" spellChecking="false"/>
+		<itemData name="Reserved Words" defStyleNum="dsBuiltIn" spellChecking="false"/>
 		<itemData name="Error" defStyleNum="dsError" spellChecking="false"/>
-		<itemData name="Operator" defStyleNum="dsSpecialChar" spellChecking="false"/>
-		<itemData name="String Char"  defStyleNum="dsSpecialChar" spellChecking="false"/>
+		<itemData name="Operator" defStyleNum="dsOperator" spellChecking="false"/>
+		<itemData name="String Char"  defStyleNum="dsString" spellChecking="false"/>
 		<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
 		<itemData name="Int" defStyleNum="dsDecVal" spellChecking="false"/>
 		<itemData name="Numeric Suffix" defStyleNum="dsDataType" spellChecking="false"/>

--- a/inst/rmarkdown/templates/reprex_document/resources/starry-nights-dark.theme
+++ b/inst/rmarkdown/templates/reprex_document/resources/starry-nights-dark.theme
@@ -1,0 +1,211 @@
+{
+  "text-color": null,
+  "background-color": null,
+  "line-number-color": "#aaaaaa",
+  "line-number-background-color": null,
+  "text-styles": {
+    "Alert": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Annotation": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Attribute": {
+      "text-color": "#7ee787",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "BaseN": {
+      "text-color": "#79c0ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "BuiltIn": {
+      "text-color": "#d2a8ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Char": {
+      "text-color": "#a5d6ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Comment": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "CommentVar": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Constant": {
+      "text-color": "#79c0ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "ControlFlow": {
+      "text-color": "#ff7b72",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "DataType": {
+      "text-color": "#79c0ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "DecVal": {
+      "text-color": "#79c0ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Documentation": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Error": {
+      "text-color": "#f0f6fc",
+      "background-color": "#8e1519",
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Extension": {
+      "text-color": "#d2a8ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Float": {
+      "text-color": "#79c0ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Function": {
+      "text-color": "#d2a8ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Import": {
+      "text-color": "#f0f6fc",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Information": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Keyword": {
+      "text-color": "#ff7b72",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Operator": {
+      "text-color": "#ff7b72",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Others": {
+      "text-color": null,
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Preprocessor": {
+      "text-color": "#ff7b72",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "SpecialChar": {
+      "text-color": "#f0f6fc",
+      "background-color": "#b62324",
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "SpecialString": {
+      "text-color": "#7ee787",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "String": {
+      "text-color": "#a5d6ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Variable": {
+      "text-color": "#ffa657",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "VerbatimString": {
+      "text-color": "#a5d6ff",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Warning": {
+      "text-color": "#9198a1",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    }
+  }
+}

--- a/inst/rmarkdown/templates/reprex_document/resources/starry-nights-light.theme
+++ b/inst/rmarkdown/templates/reprex_document/resources/starry-nights-light.theme
@@ -1,0 +1,211 @@
+{
+  "text-color": null,
+  "background-color": null,
+  "line-number-color": "#aaaaaa",
+  "line-number-background-color": null,
+  "text-styles": {
+    "Alert": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Annotation": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Attribute": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "BaseN": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "BuiltIn": {
+      "text-color": "#6639ba",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Char": {
+      "text-color": "#0a3069",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Comment": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "CommentVar": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Constant": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "ControlFlow": {
+      "text-color": "#cf222e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "DataType": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "DecVal": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Documentation": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Error": {
+      "text-color": "#f6f8fa",
+      "background-color": "#82071e",
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Extension": {
+      "text-color": "#6639ba",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Float": {
+      "text-color": "#0550ae",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Function": {
+      "text-color": "#6639ba",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Import": {
+      "text-color": "#1f2328",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Information": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Keyword": {
+      "text-color": "#cf222e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Operator": {
+      "text-color": "#cf222e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Others": {
+      "text-color": null,
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Preprocessor": {
+      "text-color": "#cf222e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "SpecialChar": {
+      "text-color": "#f6f8fa",
+      "background-color": "#cf222e",
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "SpecialString": {
+      "text-color": "#116329",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "String": {
+      "text-color": "#0a3069",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Variable": {
+      "text-color": "#953800",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "VerbatimString": {
+      "text-color": "#0a3069",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    },
+    "Warning": {
+      "text-color": "#59636e",
+      "background-color": null,
+      "bold": false,
+      "italic": false,
+      "underline": false
+    }
+  }
+}


### PR DESCRIPTION
Fixes #468 

Several changes to reprex's html preview:

1. Gain an awareness of light vs. dark mode, as reported by `rstudioapi::getThemeInfo()`, with light mode as the fall back.
   - Positron doesn't implement `rstudioapi::getThemeInfo()` yet (https://github.com/posit-dev/positron/issues/2986), but it will. In the meantime, reprex html preview will be in light mode, but that's still an improvement on the *status quo*.
1. Vendor the GitHub CSS into reprex, using <https://github.com/sindresorhus/github-markdown-css> which is more up-to-date than the rmarkdown package cd1a508d57498c389f2fb3eb1a608fdf9329f311.
1. Fixup the GitHub CSS to so that it works for our application. Most importantly for #468, we now set both the `color` and `background-color` for `<body>`, plus a few other tweaks 11eca0dd4c2d39317ec559d5ed809e6eac151c78.
1. Use a custom syntax highlighting theme that emulates what GitHub does, but shoves it into the framework that Pandoc uses (the KDE Syntax-Highlighting framework) c5747caebc01cf72d5a75f7e8ca80ddfce62fe09. Today, GitHub highlights R using a proprietary tool called PrettyLights. There's an open source project <https://github.com/wooorm/starry-night> that aims to emulate that, so that's where I got the colors from. More on this below.
1. Use `rmarkdown::pandoc_convert()` (for md-to-html conversion) in a more canonical way, which allows us to eliminate the use of a template.
1. Use a custom syntax definition for R that tweaks some peculiar choices in the definitive source = the KDE Syntax-Highlighting project 5679f011712eda932fba8da43c7c87c712db4356. More on that below.

---

#468 could be fixed just by making sure to specify both the `color` and `background-color` for `<body>`. But while I was working on this, I noticed various weird things about how R code is highlighted both on GitHub and by Pandoc! So I dug into that, which explains my forays into a custom theme and syntax definition. Hopefully this will lead to some improvements outside of reprex for syntax highlighting of R.

### GitHub side quest

I said that PrettyLights is the current highlighter for R. According to <https://github.com/wooorm/starry-night>:

> GitHub has slowly started to move towards TreeLights, which is based on TreeSitter, and also closed source. If TreeLights includes a language (currently: C, C#, CSS, CodeQL, EJS, Elixir, ERB, Gleam, Go, HTML, Java, JS, Nix, PHP, Python, RegEx, Ruby, Rust, TLA, TS), [then TreeLights is used instead of PrettyLights]

The textmate grammar that Github + PrettyLights uses for R has some shortcomings, such as not properly tokenizing / classing function calls. This is related to a separate problem @DavisVaughan has noticed, which is that click-on-a-reference doesn't pull up the symbols pane (whereas click-on-a-definition does). Davis poked at this a bit and now he's got a ticket into the right system to see if his recent tree-sitter + R successes at GitHub could possibly lead to R becoming one of the languages handled with TreeLights. I think this would lead to better syntax highlighting of R, among other benefits.

### KDE Syntax-Highlighting side quest

> Pandoc will automatically highlight syntax in [fenced code blocks](https://pandoc.org/chunkedhtml-demo/8.5-verbatim-code-blocks.html#fenced-code-blocks) that are marked with a language name. The Haskell library [skylighting](https://github.com/jgm/skylighting) is used for highlighting.

Source: <https://pandoc.org/chunkedhtml-demo/13-syntax-highlighting.html>

> If you are not satisfied with the built-in highlighting, ..., you can use the `--syntax-definition` option to load a [KDE-style XML syntax definition file](https://docs.kde.org/stable5/en/kate/katepart/highlight.html). Before writing your own, have a look at KDE’s [repository of syntax definitions](https://github.com/KDE/syntax-highlighting/tree/master/data/syntax).

Indeed I was not satisfied with the built-in highlighting, so I did have a look at KDE's repository of syntax definitions. I think the R syntax definition used by Pandoc has some strange, suboptimal choices. Here it is in various places, in increasing order of importance:

* In skylighting: <https://github.com/jgm/skylighting/blob/master/skylighting-core/xml/r.xml>
* GitHub mirror for the Kate syntax highlighting engine: <https://github.com/KDE/syntax-highlighting/blob/master/data/syntax/r.xml>
* On KDE's GitLab instance, which is the true definitive source of this XML: <https://invent.kde.org/frameworks/syntax-highlighting/-/blob/master/data/syntax/r.xml>

I engaged @cderv in some discussions around this XML and he's in agreement that we could improve it. And he has made a successful merge request before.

I opened an issue to discuss with maintainers: <https://invent.kde.org/frameworks/syntax-highlighting/-/issues/32>

Here are a few easy tweaks in this PR: 5679f011712eda932fba8da43c7c87c712db4356

