### PR TITLE
Implement figures saved locally as an option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reprex (development version)
 
+* New `local_figures` argument for `reprex()` and `reprex_document()` keeps figures as local files instead of uploading to imgur (#673, @BjarkeHautop).
+
 # reprex 2.1.1
 
 * `reprex(style = FALSE)` will never nag about installing styler (#461).

--- a/R/prex.R
+++ b/R/prex.R
@@ -41,7 +41,8 @@ prex <- function(
   style = opt(FALSE),
   html_preview = opt(TRUE),
   comment = opt("#>"),
-  tidyverse_quiet = opt(TRUE)
+  tidyverse_quiet = opt(TRUE),
+  local_figures = opt(FALSE)
 ) {
   # fmt: skip
   reprex_impl(
@@ -59,6 +60,7 @@ prex <- function(
     comment         = comment,
     tidyverse_quiet = tidyverse_quiet,
     std_out_err     = FALSE,                    # <-- different from reprex()
+    local_figures   = local_figures,
     html_preview    = html_preview
   )
 }

--- a/R/reprex-options.R
+++ b/R/reprex-options.R
@@ -12,6 +12,7 @@
 #'   * `reprex.comment`
 #'   * `reprex.tidyverse_quiet`
 #'   * `reprex.std_out_err`
+#'   * `reprex.local_figures`
 #'
 #' A few more options exist, but are only relevant to specific situations:
 #'   * `reprex.venue`: Can be used to control the `venue` used by the
@@ -44,6 +45,7 @@
 #'   reprex.comment         = "#;-)",
 #'   reprex.tidyverse_quiet = FALSE,
 #'   reprex.std_out_err     = TRUE,
+#'   reprex.local_figures   = TRUE,
 #'   reprex.venue           = "html", # NOTE: only affects reprex_selection()!
 #'   reprex.highlight.hl_style  = "acid", # NOTE: only affects RTF venue
 #'   reprex.highlight.font      = "Andale Mono Regular",

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -29,10 +29,11 @@
 #' * reprex also sets knitr's `upload.fun`. It defaults to
 #'   [knitr::imgur_upload()] so figures produced by the reprex appear properly
 #'   on GitHub, Stack Overflow, Discourse, and Slack. Note that `imgur_upload()`
-#'   requires the packages httr and xml2. When `venue = "r"`, `upload.fun` is
-#'   set to `identity()`, so that figures remain local. In that case, you may
-#'   also want to provide a filepath to `input` or set `wd`, to control where
-#'   the reprex files are written.
+#'   requires the packages httr and xml2. When `venue = "r"` or when
+#'   `local_figures = TRUE`, `upload.fun` is set to `identity()`, so that
+#'   figures remain local. In that case, you may also want to provide a
+#'   filepath to `input` or set `wd`, to control where the reprex files are
+#'   written.
 #' You can supplement or override these options with special comments in your
 #' code (see examples).
 #'
@@ -140,6 +141,14 @@
 #'   process, nor is there any guarantee that the lines from standard output and
 #'   standard error are in correct chronological order. See [callr::r()] for
 #'   more. Read more about [opt()].
+#' @param local_figures Logical. Whether to keep figures as local files,
+#'   instead of uploading them to <https://imgur.com>. Figures are saved as
+#'   `reprex-plots/plot-1.png`, `reprex-plots/plot-2.png`, etc., relative to
+#'   the current working directory, overwriting any figures left there by a
+#'   previous reprex. Each figure link in the markdown is replaced by a
+#'   visible placeholder giving the local path to the figure, i.e.
+#'   "Insert plot here: <path>". The HTML preview still displays the actual
+#'   figures. Read more about [opt()].
 #' @param html_preview Logical. Whether to show rendered output in a viewer
 #'   (RStudio or browser). Always `FALSE` in a noninteractive session. Read more
 #'   about [opt()].
@@ -274,6 +283,7 @@ reprex <- function(
   comment = opt("#>"),
   tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE),
+  local_figures = opt(FALSE),
   html_preview = opt(TRUE),
 
   outfile = deprecated(),
@@ -311,6 +321,7 @@ reprex <- function(
     comment         = comment,
     tidyverse_quiet = tidyverse_quiet,
     std_out_err     = std_out_err,
+    local_figures   = local_figures,
 
     outfile = outfile
   )

--- a/R/reprex_document.R
+++ b/R/reprex_document.R
@@ -15,6 +15,7 @@
 #'     - `style`
 #'     - `comment`
 #'     - `tidyverse_quiet`
+#'     - `local_figures` (also consulted by [reprex_render()])
 #'
 #' RStudio users can create new R Markdown documents with the
 #' `reprex_document()` format using built-in templates. Do
@@ -41,6 +42,7 @@ reprex_document <- function(
   comment = opt("#>"),
   tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE),
+  local_figures = opt(FALSE),
   pandoc_args = NULL
 ) {
   venue <- tolower(venue)
@@ -54,10 +56,12 @@ reprex_document <- function(
   comment <- arg_option(comment)
   tidyverse_quiet <- arg_option(tidyverse_quiet)
   std_out_err <- arg_option(std_out_err)
+  local_figures <- arg_option(local_figures)
 
   stopifnot(is_bool(advertise), is_bool(session_info), is_bool(style))
   stopifnot(is.character(comment))
   stopifnot(is_bool(tidyverse_quiet), is_bool(std_out_err))
+  stopifnot(is_bool(local_figures))
 
   opts_chunk <- list(
     # fixed defaults
@@ -74,7 +78,11 @@ reprex_document <- function(
     opts_chunk[["tidy"]] <- "styler"
   }
   opts_knit <- list(
-    upload.fun = switch(venue, r = identity, knitr::imgur_upload)
+    upload.fun = if (venue == "r" || local_figures) {
+      identity
+    } else {
+      knitr::imgur_upload
+    }
   )
 
   pandoc_args <- c(

--- a/R/reprex_impl.R
+++ b/R/reprex_impl.R
@@ -13,6 +13,7 @@ reprex_impl <- function(
   comment = opt("#>"),
   tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE),
+  local_figures = opt(FALSE),
   html_preview = opt(TRUE),
 
   outfile = deprecated()
@@ -30,6 +31,7 @@ reprex_impl <- function(
   comment <- arg_option(comment)
   tidyverse_quiet <- arg_option(tidyverse_quiet)
   std_out_err <- arg_option(std_out_err)
+  local_figures <- arg_option(local_figures)
 
   if (!is.null(input)) {
     stopifnot(is.character(input))
@@ -41,6 +43,7 @@ reprex_impl <- function(
   stopifnot(is_bool(html_preview), is_bool(render))
   stopifnot(is.character(comment))
   stopifnot(is_bool(tidyverse_quiet), is_bool(std_out_err))
+  stopifnot(is_bool(local_figures))
 
   if (lifecycle::is_present(outfile)) {
     stopifnot(is.character(outfile) || is.na(outfile))
@@ -80,7 +83,8 @@ reprex_impl <- function(
     style = style,
     comment = comment,
     tidyverse_quiet = tidyverse_quiet,
-    std_out_err = std_out_err
+    std_out_err = std_out_err,
+    local_figures = local_figures
   )
   src <- c(yamlify(reprex_document_options), "", src)
   if (reprex_files$chatty) {
@@ -183,7 +187,8 @@ remove_defaults <- function(x) {
     style = FALSE,
     comment = "#>",
     tidyverse_quiet = TRUE,
-    std_out_err = FALSE
+    std_out_err = FALSE,
+    local_figures = FALSE
   )
 
   compare_one <- function(nm) identical(x[[nm]], defaults[[nm]])

--- a/R/reprex_render.R
+++ b/R/reprex_render.R
@@ -71,6 +71,7 @@ reprex_render_impl <- function(input, new_session = TRUE, html_preview = NULL) {
 
   venue <- yaml_opts[["venue"]] %||% "gh"
   comment <- yaml_opts[["comment"]] %||% "#>"
+  local_figures <- yaml_opts[["local_figures"]] %||% FALSE
 
   html_preview <-
     html_preview %||% yaml_opts[["html_preview"]] %||% is_interactive_ish()
@@ -165,6 +166,19 @@ reprex_render_impl <- function(input, new_session = TRUE, html_preview = NULL) {
     )
   }
 
+  # something that would naturally go in a post_processor, but can't
+  # (see below)
+  # the preview must also be generated before figure links are (possibly)
+  # replaced with placeholders, so that local figures still display in the
+  # preview
+  if (html_preview) {
+    preview(md_file)
+  }
+
+  if (isTRUE(local_figures)) {
+    pp_figure_placeholders(md_file)
+  }
+
   # we can almost use the post_processor of output_format, but sadly we cannot
   # we can't inject std_out_err until the connection to std_file is closed
   # and we can't post process until the injection is done
@@ -177,11 +191,6 @@ reprex_render_impl <- function(input, new_session = TRUE, html_preview = NULL) {
     md_file
   )
 
-  # also something that would naturally go in a post_processor, but can't
-  # (see above)
-  if (html_preview) {
-    preview(md_file)
-  }
   invisible(reprex_file)
 }
 
@@ -350,6 +359,39 @@ remove_info_strings <- function(x) {
 # output: https://i.imgur.com/woc4vHs.png
 simplify_image_links <- function(x) {
   sub("(^!\\[\\]\\()(.+)(\\)$)", "\\2", x, perl = TRUE)
+}
+
+# used when local_figures is TRUE
+# input:  ![](foofy_reprex_files/figure-gfm/blah-1.png)<!-- -->
+# output: **Insert plot here:** `reprex-plots/plot-1.png`
+# the figure files are moved into plot_dir, relative to the current working
+# directory, and renamed plot-1.png, plot-2.png, etc., in order of appearance;
+# existing files with those names are overwritten
+pp_figure_placeholders <- function(input, plot_dir = "reprex-plots") {
+  path <- md_file(input)
+  md_lines <- read_lines(path)
+
+  regex <- "^!\\[\\]\\((.+?)\\)(<!-- -->)?$"
+  link_path <- sub(regex, "\\1", md_lines, perl = TRUE)
+  figure_dir <- paste0(path_ext_remove(path_file(path)), "_files/")
+  target <- grepl(regex, md_lines, perl = TRUE) &
+    startsWith(link_path, figure_dir)
+  if (!any(target)) {
+    return(path)
+  }
+
+  figure_path <- link_path[target]
+  plot_path <- path(
+    plot_dir,
+    glue("plot-{seq_along(figure_path)}.{path_ext(figure_path)}")
+  )
+  dir_create(plot_dir)
+  file_copy(path(path_dir(path), figure_path), plot_path, overwrite = TRUE)
+  file_delete(path(path_dir(path), figure_path))
+
+  md_lines[target] <- as.character(glue("**Insert plot here:** `{plot_path}`"))
+  write_lines(md_lines, path)
+  path
 }
 
 # used when venue is "rtf"

--- a/man/reprex.Rd
+++ b/man/reprex.Rd
@@ -16,6 +16,7 @@ reprex(
   comment = opt("#>"),
   tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE),
+  local_figures = opt(FALSE),
   html_preview = opt(TRUE),
   outfile = deprecated(),
   show = deprecated(),
@@ -103,6 +104,15 @@ process, nor is there any guarantee that the lines from standard output and
 standard error are in correct chronological order. See \code{\link[callr:r]{callr::r()}} for
 more. Read more about \code{\link[=opt]{opt()}}.}
 
+\item{local_figures}{Logical. Whether to keep figures as local files,
+instead of uploading them to \url{https://imgur.com}. Figures are saved as
+\verb{reprex-plots/plot-1.png}, \verb{reprex-plots/plot-2.png}, etc., relative to
+the current working directory, overwriting any figures left there by a
+previous reprex. Each figure link in the markdown is replaced by a
+visible placeholder giving the local path to the figure, i.e.
+"Insert plot here: \if{html}{\out{<path>}}". The HTML preview still displays the actual
+figures. Read more about \code{\link[=opt]{opt()}}.}
+
 \item{html_preview}{Logical. Whether to show rendered output in a viewer
 (RStudio or browser). Always \code{FALSE} in a noninteractive session. Read more
 about \code{\link[=opt]{opt()}}.}
@@ -151,10 +161,11 @@ reporting.
 \item reprex also sets knitr's \code{upload.fun}. It defaults to
 \code{\link[knitr:imgur_upload]{knitr::imgur_upload()}} so figures produced by the reprex appear properly
 on GitHub, Stack Overflow, Discourse, and Slack. Note that \code{imgur_upload()}
-requires the packages httr and xml2. When \code{venue = "r"}, \code{upload.fun} is
-set to \code{identity()}, so that figures remain local. In that case, you may
-also want to provide a filepath to \code{input} or set \code{wd}, to control where
-the reprex files are written.
+requires the packages httr and xml2. When \code{venue = "r"} or when
+\code{local_figures = TRUE}, \code{upload.fun} is set to \code{identity()}, so that
+figures remain local. In that case, you may also want to provide a
+filepath to \code{input} or set \code{wd}, to control where the reprex files are
+written.
 You can supplement or override these options with special comments in your
 code (see examples).
 }

--- a/man/reprex_document.Rd
+++ b/man/reprex_document.Rd
@@ -12,6 +12,7 @@ reprex_document(
   comment = opt("#>"),
   tidyverse_quiet = opt(TRUE),
   std_out_err = opt(FALSE),
+  local_figures = opt(FALSE),
   pandoc_args = NULL
 )
 }
@@ -71,6 +72,15 @@ process, nor is there any guarantee that the lines from standard output and
 standard error are in correct chronological order. See \code{\link[callr:r]{callr::r()}} for
 more. Read more about \code{\link[=opt]{opt()}}.}
 
+\item{local_figures}{Logical. Whether to keep figures as local files,
+instead of uploading them to \url{https://imgur.com}. Figures are saved as
+\verb{reprex-plots/plot-1.png}, \verb{reprex-plots/plot-2.png}, etc., relative to
+the current working directory, overwriting any figures left there by a
+previous reprex. Each figure link in the markdown is replaced by a
+visible placeholder giving the local path to the figure, i.e.
+"Insert plot here: \if{html}{\out{<path>}}". The HTML preview still displays the actual
+figures. Read more about \code{\link[=opt]{opt()}}.}
+
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 }
 \value{
@@ -95,6 +105,7 @@ influence:
 \item \code{style}
 \item \code{comment}
 \item \code{tidyverse_quiet}
+\item \code{local_figures} (also consulted by \code{\link[=reprex_render]{reprex_render()}})
 }
 }
 

--- a/man/reprex_options.Rd
+++ b/man/reprex_options.Rd
@@ -17,6 +17,7 @@ ones:
 \item \code{reprex.comment}
 \item \code{reprex.tidyverse_quiet}
 \item \code{reprex.std_out_err}
+\item \code{reprex.local_figures}
 }
 
 A few more options exist, but are only relevant to specific situations:
@@ -52,6 +53,7 @@ the sake of exposition:
   reprex.comment         = "#;-)",
   reprex.tidyverse_quiet = FALSE,
   reprex.std_out_err     = TRUE,
+  reprex.local_figures   = TRUE,
   reprex.venue           = "html", # NOTE: only affects reprex_selection()!
   reprex.highlight.hl_style  = "acid", # NOTE: only affects RTF venue
   reprex.highlight.font      = "Andale Mono Regular",

--- a/tests/testthat/test-local-figures.R
+++ b/tests/testthat/test-local-figures.R
@@ -1,0 +1,81 @@
+test_that("pp_figure_placeholders() moves figures and inserts placeholders", {
+  local_temp_wd()
+
+  dir_create("foo_reprex_files/figure-gfm")
+  write_lines("not really a png", "foo_reprex_files/figure-gfm/blah-1.png")
+  write_lines("not really a png", "foo_reprex_files/figure-gfm/blah-2.png")
+  # fmt: skip
+  md_lines <- c(
+    "``` r",
+    "plot(1:3)",
+    "```",
+    "![](foo_reprex_files/figure-gfm/blah-1.png)<!-- -->",
+    "![](foo_reprex_files/figure-gfm/blah-2.png)",
+    "![](https://i.imgur.com/woc4vHs.png)<!-- -->",
+    "![](some-other-local-file.png)",
+    "some prose"
+  )
+  write_lines(md_lines, "foo_reprex.md")
+
+  pp_figure_placeholders("foo_reprex.md")
+
+  out <- read_lines("foo_reprex.md")
+  expect_equal(out[1:3], md_lines[1:3])
+  expect_equal(out[4], "**Insert plot here:** `reprex-plots/plot-1.png`")
+  expect_equal(out[5], "**Insert plot here:** `reprex-plots/plot-2.png`")
+  # links to remote figures and to files reprex did not create are left as is
+  expect_equal(out[6:8], md_lines[6:8])
+
+  expect_true(file_exists("reprex-plots/plot-1.png"))
+  expect_true(file_exists("reprex-plots/plot-2.png"))
+  expect_false(file_exists("foo_reprex_files/figure-gfm/blah-1.png"))
+  expect_false(file_exists("some-other-local-file.png"))
+})
+
+test_that("local_figures = TRUE saves figures to reprex-plots, with placeholders", {
+  skip_on_cran()
+  local_temp_wd()
+
+  # note: no `input` filepath and no `wd`, so the reprex itself is rendered in
+  # a subdirectory of the session temp dir, but figures must still land here
+  out <- reprex(
+    input = c("plot(1:3)", "hist(rnorm(100))"),
+    local_figures = TRUE
+  )
+
+  placeholder <- grep("Insert plot here", out, value = TRUE)
+  expect_length(placeholder, 2)
+  expect_match(placeholder[1], "`reprex-plots/plot-1.png`", fixed = TRUE)
+  expect_match(placeholder[2], "`reprex-plots/plot-2.png`", fixed = TRUE)
+  expect_true(file_exists("reprex-plots/plot-1.png"))
+  expect_true(file_exists("reprex-plots/plot-2.png"))
+
+  # no figure link is left behind
+  expect_no_match(out, "!\\[\\]")
+})
+
+test_that("local figures are embedded in the HTML preview", {
+  skip_on_cran()
+  local_temp_wd()
+
+  write_lines("plot(1:3)\n", "foo.R")
+  reprex(input = "foo.R", local_figures = TRUE, render = FALSE)
+
+  withr::local_envvar(c(RMARKDOWN_PREVIEW_DIR = "."))
+  rlang::local_interactive(FALSE)
+
+  capture.output(
+    reprex_render("foo_reprex.R", html_preview = TRUE),
+    type = "message"
+  )
+
+  # the markdown holds the placeholder, not a figure link
+  md_lines <- read_lines("foo_reprex.md")
+  expect_match(md_lines, "Insert plot here", all = FALSE)
+  expect_true(file_exists("reprex-plots/plot-1.png"))
+
+  # but the preview shows the actual figure, embedded as a data URI
+  preview_lines <- read_lines("foo_reprex_preview.html")
+  expect_match(preview_lines, "data:image/png;base64", all = FALSE)
+  expect_no_match(preview_lines, "Insert plot here")
+})


### PR DESCRIPTION
Implements an option to save plots generated via `reprex()` to be saved locally instead of uploaded to imgur, and the plots are saved in `./regrex-plots` by default. Useful for places where imgur is blocked as in #483 and to share plots you don't want uploaded as in e.g. #214.

The copied .md text then contains a placeholder text where the user should insert the image. In the rendered preview the placeholder text is replaced with the path to the plot, so the user in the preview still sees the plot.

Fixes #483
Fixes #214